### PR TITLE
New rule: detection of common obfuscation methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ GuardDog comes with 2 types of heuristics:
 | [Exfiltration of sensitive data to a remote server](https://github.com/DataDog/guarddog/blob/main/guarddog/analyzer/sourcecode/exfiltrate-sensitive-data.yml) | Sensitive data from the environment ends up being sent through an HTTP request |
 | [Code execution in `setup.py`](https://github.com/DataDog/guarddog/blob/main/guarddog/analyzer/sourcecode/code-execution.yml) | Code in `setup.py` executes code dynamically or starts a new process |
 | [Unusual domain extension](https://github.com/DataDog/guarddog/blob/main/guarddog/analyzer/sourcecode/shady-links.yml) | Usage of a domain name with an extension frequently used by malware (e.g. `.xyz` or `.top`) |
+| [Use of a common obfuscation method](https://github.com/DataDog/guarddog/blob/main/guarddog/analyzer/sourcecode/obfuscation.yml) | The package uses an obfuscation method commonly used by malware, such as running `eval` on hexadecimal strings |
 
 ### Package metadata heuristics
 

--- a/guarddog/analyzer/sourcecode/obfuscation.yml
+++ b/guarddog/analyzer/sourcecode/obfuscation.yml
@@ -1,0 +1,14 @@
+rules:
+  - id: obfuscation
+    message: "Detected common obfuscation method used by malware"
+    patterns:
+      - pattern-either:
+        # evaluates to "eval"
+        - pattern: 'eval("\145\166\141\154")'
+        # evaluates to "eval"
+        - pattern: 'eval("\x65\x76\x61\x6c")'
+        # this naming is used by some obfuscators such as BlankOBF
+        - pattern: '_____=eval(...)'
+    languages:
+      - python
+    severity: WARNING

--- a/tests/analyzer/sourcecode/obfuscation.py
+++ b/tests/analyzer/sourcecode/obfuscation.py
@@ -1,0 +1,11 @@
+# Obfuscated with BlankOBF
+# https://github.com/Blank-c/BlankOBF
+
+# ruleid: obfuscation
+_____=eval("\145\166\141\154")
+
+# ruleid: obfuscation
+_____ = eval("foo")
+
+# ok: obfuscation
+eval("foo")


### PR DESCRIPTION
To catch scripts obfuscated with https://github.com/Blank-c/BlankOBF. 

Sample packages: `aowdjpawojd`

```
obfuscation: found 1 source code matches
  * Detected common obfuscation method used by malware at aowdjpawojd-0.0.0/aowdjpawojd/__init__.py:3
        _____=eval("\x65\166\141\x6c");_______=_____("\x63\157\x6d\x70\x69\x6c\145");______,____=_____(_______("\137\x5f\x69\x6d\x70\157\162\164\x5f\137\50\x27\142\141\163\145\x36\64\x27\51","",_____.__name__)),_____(_______("\137\x5f\x69\155\160\x...__name__))
```