### PR TITLE
New metadata rule: package version to 0.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ GuardDog comes with 2 types of heuristics:
 | Typosquatting | Package has a name close to one of the top 5k PyPI packages |
 | Potentially compromised maintainer e-mail domain | Maintainer e-mail address is associated to a domain that was re-registered later than the last package release. This can be an indicator that this is a custom domain that expired, and was leveraged by an attacker to compromise the package owner's PyPI account. See [here](https://therecord.media/thousands-of-npm-accounts-use-email-addresses-with-expired-domains) for a description of the issue for npm. |
 | Empty package description | Package has an empty description of PyPI |
+| Release 0.0.0 | Package has its latest release set to `0.0.0` or `0.0` |
 
 ## Development
 

--- a/guarddog/analyzer/analyzer.py
+++ b/guarddog/analyzer/analyzer.py
@@ -6,6 +6,7 @@ from semgrep.semgrep_main import invoke_semgrep
 from guarddog.analyzer.metadata.potentially_compromised_email_domain import PotentiallyCompromisedEmailDomainDetector
 from guarddog.analyzer.metadata.empty_information import EmptyInfoDetector
 from guarddog.analyzer.metadata.typosquatting import TyposquatDetector
+from guarddog.analyzer.metadata.release_zero import ReleaseZeroDetector
 
 
 class Analyzer:
@@ -58,6 +59,7 @@ class Analyzer:
             "typosquatting": TyposquatDetector(),
             "potentially_compromised_email_domain": PotentiallyCompromisedEmailDomainDetector(),
             "empty_information": EmptyInfoDetector(),
+            "release_zero": ReleaseZeroDetector()
         }
 
     def analyze(self, path, info=None, rules=None) -> dict[str]:

--- a/guarddog/analyzer/metadata/release_zero.py
+++ b/guarddog/analyzer/metadata/release_zero.py
@@ -1,0 +1,15 @@
+""" Empty Information Detector
+
+Detects when a package has its latest release version to 0.0.0
+"""
+
+
+from guarddog.analyzer.metadata.detector import Detector
+
+
+class ReleaseZeroDetector(Detector):
+    def __init__(self) -> None:
+        super()
+
+    def detect(self, package_info) -> tuple[bool, str]:
+        return package_info["info"]['version'] in ['0.0.0', '0.0'], "The package has its latest release version to 0.0.0"

--- a/tests/analyzer/metadata/test_release_zero.py
+++ b/tests/analyzer/metadata/test_release_zero.py
@@ -1,0 +1,23 @@
+import pytest
+
+from guarddog.analyzer.metadata.release_zero import ReleaseZeroDetector
+from tests.analyzer.metadata.resources.sample_project_info import (
+    PACKAGE_INFO,
+    generate_project_info,
+)
+
+
+class TestEmptyInformation:
+    detector = ReleaseZeroDetector()
+    nonzero_release = PACKAGE_INFO
+    zero_release = generate_project_info("version", "0.0.0")
+
+    @pytest.mark.parametrize("package_info", [zero_release])
+    def test_zero(self, package_info):
+        matches, _ = self.detector.detect(package_info)
+        assert matches
+
+    @pytest.mark.parametrize("package_info", [nonzero_release])
+    def test_nonempty(self, package_info):
+        matches, _ = self.detector.detect(package_info)
+        assert not matches


### PR DESCRIPTION
Noticed that most malware has its version set to `0.0.0`.

Sample output:
![image](https://user-images.githubusercontent.com/136675/200516524-b324a74a-0563-421b-8b7a-c2c6d5f84fd8.png)
