### PR TITLE
Handle Exceptions For Running All Rules in analyze_sourcecode

### DIFF
--- a/guarddog/analyzer/analyzer.py
+++ b/guarddog/analyzer/analyzer.py
@@ -132,7 +132,7 @@ class Analyzer:
                     issues += 1
                     results[rule] = message
             except Exception as e:
-                errors[rule] = str(e)
+                errors[rule] = f"failed to run rule {rule}: {str(e)}"
 
         return {"results": results, "errors": errors, "issues": issues}
 
@@ -156,11 +156,14 @@ class Analyzer:
 
         if rules is None:
             # No rule specified, run all rules
-            response = invoke_semgrep(Path(self.sourcecode_path), [targetpath], exclude=self.exclude, no_git_ignore=True)
-            rule_results = self._format_semgrep_response(response, targetpath=targetpath)
-            issues += len(rule_results)
-            
-            results = results | rule_results
+            try:
+                response = invoke_semgrep(Path(self.sourcecode_path), [targetpath], exclude=self.exclude, no_git_ignore=True)
+                rule_results = self._format_semgrep_response(response, targetpath=targetpath)
+                issues += len(rule_results)
+                
+                results = results | rule_results
+            except Exception as e:
+                errors["rules-all"] = f"failed to run rule: {str(e)}"
         else:
             for rule in rules:
                 try:
@@ -175,7 +178,7 @@ class Analyzer:
 
                     results = results | rule_results
                 except Exception as e:
-                    errors[rule] = str(e)
+                    errors[rule] = f"failed to run rule {rule}: {str(e)}"
 
         return {"results": results, "errors": errors, "issues": issues}
 

--- a/guarddog/scanners/package_scanner.py
+++ b/guarddog/scanners/package_scanner.py
@@ -80,9 +80,7 @@ class PackageScanner(Scanner):
 
                 return results
         except Exception as e:
-            sys.stderr.write("\n")
-            sys.stderr.write(str(e))
-            sys.exit()
+            raise Exception(e)
 
     def download_package(self, package_name, directory, version=None) -> None:
         """Downloads the PyPI distribution for a given package and version


### PR DESCRIPTION
### Why this PR
When scanning one package, I get a mysterious exception from scan_remote(). 

<img width="599" alt="Screen Shot 2022-11-17 at 3 45 07 PM" src="https://user-images.githubusercontent.com/88739846/202555974-5171b913-6f0a-4bf7-8282-db64bb422012.png">

The root cause is the lack of a try catch block for the case of scanning on all source code rules in analyze_sourcecode(), which results in ending execution early if any of the rules throw an exception instead of returning some kind of result. 

During debugging, I also noticed the lack of a rule name in semgrep exceptions, so I added some context when returning errors from the analyze_* functions. 

```
File "/opt/homebrew/Cellar/python@3.11/3.11.0/Frameworks/Python.framework/Versions/3.11/lib/python3.11/asyncio/base_events.py", line 650, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/d.niu/Library/Caches/pypoetry/virtualenvs/guarddog-VURbeFh0-py3.11/lib/python3.11/site-packages/semgrep/core_runner.py", line 257, in _stream_subprocess
    raise SemgrepError(f"Error while running rules: {r}")
semgrep.error.SemgrepError: Error while running rules: 0 bytes read on a total of 2 expected bytes
```

### Open Question
However, we now don't get context for which rule produced an error in the case of running all rules because of the lack of rule iteration in analyze_sourcecode(). We could benefit from just iterating through all rules in either case so we retain this information.

<img width="728" alt="Screen Shot 2022-11-17 at 3 53 22 PM" src="https://user-images.githubusercontent.com/88739846/202557478-7e19399a-ccfd-41c5-a8a1-dc41c606f202.png">
