### PR TITLE
Package Release Digest Metadata Detector

### DIFF
--- a/guarddog/analyzer/analyzer.py
+++ b/guarddog/analyzer/analyzer.py
@@ -7,6 +7,7 @@ from guarddog.analyzer.metadata.potentially_compromised_email_domain import Pote
 from guarddog.analyzer.metadata.empty_information import EmptyInfoDetector
 from guarddog.analyzer.metadata.typosquatting import TyposquatDetector
 from guarddog.analyzer.metadata.release_zero import ReleaseZeroDetector
+from guarddog.analyzer.metadata.match_github_source import MatchGithubSource
 
 
 class Analyzer:
@@ -59,7 +60,8 @@ class Analyzer:
             "typosquatting": TyposquatDetector(),
             "potentially_compromised_email_domain": PotentiallyCompromisedEmailDomainDetector(),
             "empty_information": EmptyInfoDetector(),
-            "release_zero": ReleaseZeroDetector()
+            "release_zero": ReleaseZeroDetector(),
+            "match_github_source": MatchGithubSource()
         }
 
     def analyze(self, path, info=None, rules=None) -> dict[str]:

--- a/guarddog/analyzer/metadata/match_github_source.py
+++ b/guarddog/analyzer/metadata/match_github_source.py
@@ -1,0 +1,130 @@
+"""Match Github Source
+
+Does the build artifact (.tar.gz) listed on pypi match the build artifact of the same release for the project on Github? 
+"""
+from guarddog.analyzer.metadata.detector import Detector
+from urllib.parse import urlparse, urlunparse
+import hashlib
+import json
+import os
+import requests
+import re
+import tempfile
+
+class MatchGithubSource(Detector):
+    """
+    Detector for any differences between the build artifact listed on the pypi website and that of the package's corresponding Github release
+    
+    Args:
+        Detector (_type_): Detector class defined in guarddog.analyzer.metadata.detector
+    
+    Raises:
+
+
+    Returns:
+    """
+
+    def __init__(self) -> None:
+        super()
+        self.username = os.system('git config --global user.name')
+        self.token = os.getenv('GIT_PAT_TOKEN')
+    
+    def detect(self, package_info) -> tuple[bool, str]:
+        if self.token == "":
+            raise Exception("cannot match pypi releases with source release code: no Github personal token provided as environment variable 'GIT_PAT_TOKEN'")
+        
+        elif self.username == "":
+            raise Exception("cannot match pypi releases with source release code: no Github username provided in the global git config")
+
+        home_page = package_info["info"]["home_page"]
+        nested_home_page = package_info["info"]["project_urls"]["Homepage"]
+        if home_page != "":
+            try:
+                u = urlparse(home_page)
+                if u.hostname == "github.com":
+                    releases = _get_git_builds(home_page, "releases", self.username, self.token)
+                    if len(releases) > 0:
+                        _match_releases(pypireleases= package_info['releases'], githubreleases=releases, username=self.username, token=self.token)
+                    else:
+                        tags = _get_git_builds(home_page, "tags", self.username, self.token)
+                        if len(tags) > 0:
+                            _match_releases(pypireleases= package_info['releases'], githubreleases=tags, username=self.username, token=self.token)
+                else: 
+                    return [False, 'project not hosted on Github'] #TODO: return proper error
+            except Exception as e:
+                raise Exception(f"error parsing package_info for homepage url: {e}")
+        elif nested_home_page != "":
+            try:
+                u = urlparse(nested_home_page)
+                if u.hostname == "github.com":
+                    releases = _get_git_builds(nested_home_page, "releases", self.username, self.token)
+                    if len(releases) > 0:
+                        _match_releases(pypireleases= package_info['releases'], githubreleases=releases, username=self.username, token=self.token)
+                    else:
+                        tags = _get_git_builds(nested_home_page, "tags", self.username, self.token)
+                else: 
+                    return [False, 'project not hosted on Github'] #TODO: return proper error
+            except Exception as e:
+                raise Exception(f"error parsing package_info for nested homepage url: {e}") 
+        else: #TODO: return proper error
+            return [False, "error"]         
+        return [False, "ok"]
+
+def _get_git_builds(url: str, endpoint: str, username: str, token: str) -> dict: #TODO: separate out logic for auth to helper function for PAT and github action options
+    # https://docs.github.com/en/rest/releases/releases
+    # https://docs.github.com/en/rest/repos/repos#list-repository-tags
+
+    #TODO:  validate endpoint as releases or tags
+    u = urlparse(url)
+    api_host = "api.github.com/repos"
+    path = u.path.split("/")
+    path.append(endpoint)
+    path_with_releases = "/".join(path)
+
+    new_url = urlunparse([u.scheme, api_host, path_with_releases, "", "", ""])
+
+    r = requests.get(url=new_url, auth=(username, token)).json() #TODO: CHECK TAG RETURN FORMAT
+
+    releases = {}
+
+    if len(r) != 0:
+        for release in r:
+            version = release['name']
+            if version.find("v") == 0:
+                releases[version[1:]] = release['tarball_url']
+
+    return releases
+
+def _match_releases(pypireleases: dict, githubreleases: dict, username: str, token: str) -> tuple[bool, str]:
+     res = {}
+     for release, r_formats in pypireleases.items():
+        for r in r_formats: 
+            if r['packagetype'] == "sdist":
+                pypi_digest = r['digests']['sha256']
+                github_tar_url =  githubreleases[release]
+                github_digest = _get_digest_from_url(github_url=github_tar_url, username=username, token=token)
+                
+                #print(f"pypi digest is {pypi_digest} from {pypi_tar_url}, github digest is {github_digest} from {github_tar_url}")
+                if pypi_digest == github_digest:
+                    res[release] = (True, "")
+                else:
+                    res[release] = (False, "releases do not match! D:")
+
+def _get_digest_from_url(github_url: str, username: str, token: str) -> bool:    
+    g = urlparse(github_url)
+    if g.scheme != "https" or g.hostname != "api.github.com":
+        raise Exception("malformed github url")
+    
+    zip_r = requests.get(url=github_url, auth=(username, token))
+    
+    github_checksum = _calculate_checksum(bytes(zip_r.text, 'utf-8'))
+
+    return github_checksum
+
+def _calculate_checksum(tar: bytes) -> int:
+    try:
+        h = hashlib.sha256()
+        h.update(tar)
+        return h.hexdigest()
+    except Exception as e:
+        raise(e)

--- a/guarddog/analyzer/metadata/potentially_compromised_email_domain.py
+++ b/guarddog/analyzer/metadata/potentially_compromised_email_domain.py
@@ -18,7 +18,7 @@ class PotentiallyCompromisedEmailDomainDetector(Detector):
     reregistered before the most recent package released
 
     Args:
-        Detector (_type_): _description_
+        Detector (_type_): Detector class defined in guarddog.analyzer.metadata.detector
     """
 
     def __init__(self) -> None:

--- a/guarddog/cli.py
+++ b/guarddog/cli.py
@@ -77,7 +77,7 @@ def scan(identifier, version, rules, exclude_rules, json):
 
     if json:
         import json as js
-        print(js.dumps(results))
+        print(js.dumps(results, indent = 4))
     else:
         print_scan_results(results, identifier)
 

--- a/guarddog/scanners/package_scanner.py
+++ b/guarddog/scanners/package_scanner.py
@@ -4,6 +4,7 @@ import sys
 import tarfile
 import tempfile
 import requests
+import json
 
 from guarddog.analyzer.analyzer import Analyzer
 from guarddog.scanners.scanner import Scanner


### PR DESCRIPTION
### Why this PR
We want to see if there has been tampering between Github releases and pypi listing of the package. Specifically, does the build artifact (.tar.gz) listed on pypi match the build artifact of the same release for the project on Github? This PR adds a new metadata detector named Match Github Source. 

### Testing
Tested on a locally built virtual environment and only on one package. To use, set environment variable `GIT_PAT_TOKEN` to a [personal access token](https://docs.github.com/en/enterprise-server@3.4/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). This PAT can have no permissions granted during creation- it will still work.
#### Note
Detect doesn't return anything useful right now, namely because the releases/tags on Github are inherently different from the pypi releases listed in the pypi package's api. For example, PKG-INFO only exist in pypi tarballs, while most Github releases/tags tarballs contain files like READMEs and other docs that aren't included in pypi tarballs. 

I left one print statement in the PR that better illustrates this if uncommented out and ran against a single package. 

### To do
See what kinds of integrity checks are actually feasible. 