### PR TITLE
Added setuptools as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,8 @@ pytest = "^7.1.2"
 flake8 = "^5.0.4"
 python-whois = "^0.8.0"
 termcolor = "^2.1.0"
-
+setuptools = "^65.6.3"
+    
 [tool.poetry.dev-dependencies]
 
 [build-system]

--- a/requirements.txt
+++ b/requirements.txt
@@ -285,3 +285,5 @@ wcmatch==8.4 ; python_version >= "3.10" and python_version < "4" \
 websocket-client==1.3.3 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:5d55652dc1d0b3c734f044337d929aaf83f4f9138816ec680c1aefefb4dc4877 \
     --hash=sha256:d58c5f284d6a9bf8379dab423259fe8f85b70d5fa5d2916d5791a84594b122b1
+setuptools==65.6.3 ; python_version >= "3.10" and python_version < "4" \
+    --hash=sha256:57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54


### PR DESCRIPTION
## Description
I might be a one-off. But not all distributions come with [setuptools](https://pypi.org/project/setuptools/) bundled with Python.
Since the project utilizes [pkg_resources](https://setuptools.pypa.io/en/latest/pkg_resources.html) which is AFAIK a resources from `setuptools` to among other things discover plugins and source files. This needs to be in the requirements/dependency list.

## Error
```
Traceback (most recent call last):
  File "/usr/sbin/guarddog", line [5](https://github.com/Torxed/archoffline/actions/runs/3541311385/jobs/5945421906#step:9:6), in <module>
    from guarddog.cli import cli
  File "/usr/lib/python3.10/site-packages/guarddog/cli.py", line 1[7](https://github.com/Torxed/archoffline/actions/runs/3541311385/jobs/5945421906#step:9:8), in <module>
    from .scanners.project_scanner import RequirementsScanner
  File "/usr/lib/python3.10/site-packages/guarddog/scanners/project_scanner.py", line [8](https://github.com/Torxed/archoffline/actions/runs/3541311385/jobs/5945421906#step:9:9), in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

## Steps to reproduce

Install a vanilla Arch Linux installation (or a venv I guess).
Install `git python python-pip` and run:
```
$ pip install git+https://github.com/DataDog/guarddog.git
```
And then try to run guarddog against anything.
Or view the workflow of a runner that I'm using: https://github.com/Torxed/archoffline/actions/runs/3541311385/jobs/5945421906