### PR TITLE
Added exit codes

### DIFF
--- a/guarddog/cli.py
+++ b/guarddog/cli.py
@@ -81,6 +81,8 @@ def scan(identifier, version, rules, exclude_rules, json):
     else:
         print_scan_results(results, identifier)
 
+    exit(results.get('issues', 0))
+
 # Determines if the input passed to the 'scan' command is a local package name
 def is_local_package(input):
     identifier_is_path = re.search(r"(.{0,2}\/)+.+", input)
@@ -90,6 +92,7 @@ def is_local_package(input):
 # Pretty prints scan results for the console
 def print_scan_results(results, identifier):
     num_issues = results.get('issues')
+
     if num_issues == 0:
         print("Found " + colored('0 potentially malicious indicators', 'green', attrs=['bold']) + " scanning " + colored(identifier, None, attrs=['bold']))
         print()
@@ -110,5 +113,6 @@ def print_scan_results(results, identifier):
             for finding in source_code_findings:
                 print('  * ' + finding['message'] + ' at ' + finding['location'] + '\n    ' + format_code_line_for_output(finding['code']))
             print()
+
 def format_code_line_for_output(code):
     return '    ' + colored(code.strip().replace('\n', '\n    ').replace('\t', '  '), None, 'on_red', attrs=['bold'])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,8 @@ pytest = "^7.1.2"
 flake8 = "^5.0.4"
 python-whois = "^0.8.0"
 termcolor = "^2.1.0"
-
+setuptools = "^65.6.3"
+    
 [tool.poetry.dev-dependencies]
 
 [build-system]

--- a/requirements.txt
+++ b/requirements.txt
@@ -285,3 +285,5 @@ wcmatch==8.4 ; python_version >= "3.10" and python_version < "4" \
 websocket-client==1.3.3 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:5d55652dc1d0b3c734f044337d929aaf83f4f9138816ec680c1aefefb4dc4877 \
     --hash=sha256:d58c5f284d6a9bf8379dab423259fe8f85b70d5fa5d2916d5791a84594b122b1
+setuptools==65.6.3 ; python_version >= "3.10" and python_version < "4" \
+    --hash=sha256:57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54


### PR DESCRIPTION
## Description

This PR will add exit codes on `scan`.
This will help automating and adding guarddog to runners or scripts, as there's no other way to determine if guarddog found issues or not in a machine friendly way *(other than `grep [1-9]+` or some other shenanigans)*.

This will use `results['results']` counter, 0 results will exit 0 and anything above will exit with the number of issues.

## Usage

Assuming a runner similar to https://github.com/Torxed/archoffline/blob/797436de3999e73963af4b60364e0c9767afece9/.github/workflows/guarddog.yaml:
```yaml
on: [ push, pull_request ]
name: guarddog security checkup
jobs:
    guarddog:
        runs-on: ubuntu-latest
        container:
            image: archlinux:latest
        steps:
            - uses: actions/checkout@v3
            - run: pacman --noconfirm -Syu git python python-setuptools python-pip python-build
            - run: python -m pip install --upgrade pip
            - run: pip install git+https://github.com/DataDog/guarddog.git
            - run: python --version
            - name: run build
              run: python -m build
            - name: run guarddog
              run: guarddog scan dist/*.tar.gz
```
Normally, this runner could never exit with a bad exit code, leaving a green tick on github:
![screenshot](https://user-images.githubusercontent.com/861439/203864047-35bb78fa-2fc2-4c58-a4c2-22a425d12f2e.png)

When in fact, there might have been 1+ issues.
And this is due to github runners checking for non-zero exit codes (by default) to indicate if the runner had any complaints.

This should allow people to incorporate guarddog in their runners in a natural way :)

## Footnote

Cool project and fun approach to grabbing the common suspects.