### PR TITLE
Make GuardDog usable as a library rather than only a CLI

### DIFF
--- a/docs/Programmatic.md
+++ b/docs/Programmatic.md
@@ -1,0 +1,51 @@
+# Programmatic use
+
+GuardDog can be used as a Python library:
+
+```python
+from guarddog import PackageScanner
+
+scanner = PackageScanner()
+
+results = scanner.scan_remote('guarddog')
+print(results)
+```
+
+This will download the package `guarddog`, scan it and cleanup the directory from the disk.
+
+## API
+
+### Class `PackageScanner`
+
+Scans package for attack vectors based on source code and metadata rules.
+```python
+from guarddog import PackageScanner
+```
+
+#### Method `scan_remote(self, name, version=None, rules=None, base_dir=None, write_package_info=False)`
+
+Scans a remote package
+
+Arguments:
+* name (str): name of the package on PyPI
+* version (str, optional): version of package (ex. 0.0.1)
+* rules (set, optional): Set of rule names to use. Defaults to all rules.
+* base_dir (str, optional): directory to use to download package. There will be no cleanup after the scan.
+* write_package_info (bool, default False): if set to true, the result of the metadata API will be writen to a json file
+
+##### Example
+
+```python
+from guarddog import PackageScanner
+
+scanner = PackageScanner()
+
+with tempfile.TemporaryDirectory() as tmpdirname:
+    results = scanner.scan_remote(package, version, None, tmpdirname, True)  # fixing the dir prevents the cleanup
+    print(f"Found {results['issues']} issues on package {package}")
+    if results["issues"] > 0:
+        upload_scan_artifacts(s3, scan_key, results["path"], tmpdirname)
+```
+In this example, GuardDog will download and scan the package defined by `package` and `version`. It will use a provided
+temporary directory and write the Pypi metadata of the package in a JSON file.
+This can be used, for instance, to upload the findings in a specific place for review.

--- a/docs/programmatic-usage.md
+++ b/docs/programmatic-usage.md
@@ -1,4 +1,4 @@
-# Programmatic use
+# Programmatic usage
 
 GuardDog can be used as a Python library:
 
@@ -7,17 +7,18 @@ from guarddog import PackageScanner
 
 scanner = PackageScanner()
 
-results = scanner.scan_remote('guarddog')
+results = scanner.scan_remote('requests')
 print(results)
 ```
 
-This will download the package `guarddog`, scan it and cleanup the directory from the disk.
+This will download the package `requests`, scan it, then cleanup the temporary directory from disk.
 
 ## API
 
 ### Class `PackageScanner`
 
-Scans package for attack vectors based on source code and metadata rules.
+Scans package for attack vectors based on [source code](https://github.com/DataDog/guarddog/tree/main/guarddog/analyzer/sourcecode) and [metadata](https://github.com/DataDog/guarddog/tree/main/guarddog/analyzer/metadata) heuristics.
+
 ```python
 from guarddog import PackageScanner
 ```
@@ -27,13 +28,13 @@ from guarddog import PackageScanner
 Scans a remote package
 
 Arguments:
-* name (str): name of the package on PyPI
-* version (str, optional): version of package (ex. 0.0.1)
-* rules (set, optional): Set of rule names to use. Defaults to all rules.
-* base_dir (str, optional): directory to use to download package. There will be no cleanup after the scan.
-* write_package_info (bool, default False): if set to true, the result of the metadata API will be writen to a json file
+* `name` (str): name of the package on PyPI
+* `version` (str, optional): version of package (ex. 0.0.1). If not specified, the latest version is assumed.
+* `rules` (set, optional): Set of rule names to use. Defaults to all rules.
+* `base_dir` (str, optional): directory to use to download package to. If not specified, a temporary folder is created and cleaned up automatically. If not specified, the provided directory is not removed after the scan.
+* `write_package_info` (bool, default False): if set to true, the result of the PyPI metadata API is written to a JSON file where the package is downloaded.
 
-##### Example
+Example:
 
 ```python
 from guarddog import PackageScanner

--- a/guarddog/__init__.py
+++ b/guarddog/__init__.py
@@ -1,0 +1,1 @@
+from guarddog.scanners.package_scanner import PackageScanner

--- a/guarddog/analyzer/analyzer.py
+++ b/guarddog/analyzer/analyzer.py
@@ -106,7 +106,7 @@ class Analyzer:
         results = metadata_results["results"] | sourcecode_results["results"]
         errors = metadata_results["errors"] | sourcecode_results["errors"]
 
-        return {"issues": issues, "errors": errors, "results": results}
+        return {"issues": issues, "errors": errors, "results": results, "path": path}
 
     def analyze_metadata(self, info, rules=None) -> dict[str]:
         """

--- a/guarddog/cli.py
+++ b/guarddog/cli.py
@@ -4,13 +4,11 @@ CLI command that scans a PyPI package version for user-specified malware flags.
 Includes rules based on package registry metadata and source code analysis.
 """
 
-import json
-import os
 import re
-from pprint import pprint
-from termcolor import colored
+import sys
 
 import click
+from termcolor import colored
 
 from .analyzer.analyzer import Analyzer
 from .scanners.package_scanner import PackageScanner
@@ -73,7 +71,12 @@ def scan(identifier, version, rules, exclude_rules, json):
     if is_local_package(identifier):
         results = scanner.scan_local(identifier, rule_param)
     else:
-        results = scanner.scan_remote(identifier, version, rule_param)
+        try:
+            results = scanner.scan_remote(identifier, version, rule_param)
+        except Exception as e:
+            sys.stderr.write("\n")
+            sys.stderr.write(str(e))
+            sys.exit()
 
     if json:
         import json as js

--- a/guarddog/scanners/package_scanner.py
+++ b/guarddog/scanners/package_scanner.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 import sys
@@ -50,14 +51,33 @@ class PackageScanner(Scanner):
         else:
             raise Exception(f"Path {path} does not exist.")
 
-    def scan_remote(self, name, version=None, rules=None):
+    def _scan_remote(self, name, base_dir, version=None, rules=None, write_package_info=False):
+        directory = os.path.join(os.path.dirname(os.path.abspath(__file__)), base_dir)
+        file_path = os.path.join(directory, name)
+
+        self.download_package(name, directory, version)
+
+        package_info = get_package_info(name)
+
+        results = self.analyzer.analyze(file_path, package_info, rules)
+        if write_package_info:
+            suffix = f"{name}-{version}" if version is not None else name
+            with open(os.path.join(results["path"], f'package_info-{suffix}.json'), "w") as file:
+                file.write(json.dumps(package_info))
+
+        return results
+
+    def scan_remote(self, name, version=None, rules=None, base_dir=None, write_package_info=False):
         """
         Scans a remote package
 
         Args:
             name (str): name of the package on PyPI
-            version (str): verson of package (ex. 0.0.1)
+            version (str, optional): version of package (ex. 0.0.1)
             rules (set, optional): Set of rule names to use. Defaults to all rules.
+            base_dir (str, optional): directory to use to download package. There will be no cleanup after the scan
+            write_package_info (bool, default False): if set to true, the result of the metadata API will be writen to a
+                json file
 
         Raises:
             Exception: Analyzer exception
@@ -65,24 +85,12 @@ class PackageScanner(Scanner):
         Returns:
             dict: Analyzer output with rules to results mapping
         """
+        if (base_dir is not None):
+            return self._scan_remote(name, base_dir, version, rules, write_package_info)
 
-        try:
-            with tempfile.TemporaryDirectory() as tmpdirname:
-                # Directory to download compressed and uncompressed package
-                directory = os.path.join(os.path.dirname(os.path.abspath(__file__)), tmpdirname)
-                file_path = os.path.join(directory, name)
-
-                self.download_package(name, directory, version)
-
-                package_info = get_package_info(name)
-
-                results = self.analyzer.analyze(file_path, package_info, rules)
-
-                return results
-        except Exception as e:
-            sys.stderr.write("\n")
-            sys.stderr.write(str(e))
-            sys.exit()
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            # Directory to download compressed and uncompressed package
+            return self._scan_remote(name, tmpdirname, version, rules)
 
     def download_package(self, package_name, directory, version=None) -> None:
         """Downloads the PyPI distribution for a given package and version

--- a/guarddog/scanners/package_scanner.py
+++ b/guarddog/scanners/package_scanner.py
@@ -72,12 +72,11 @@ class PackageScanner(Scanner):
         Scans a remote package
 
         Args:
-            name (str): name of the package on PyPI
-            version (str, optional): version of package (ex. 0.0.1)
-            rules (set, optional): Set of rule names to use. Defaults to all rules.
-            base_dir (str, optional): directory to use to download package. There will be no cleanup after the scan
-            write_package_info (bool, default False): if set to true, the result of the metadata API will be writen to a
-                json file
+            * `name` (str): name of the package on PyPI
+            * `version` (str, optional): version of package (ex. 0.0.1). If not specified, the latest version is assumed.
+            * `rules` (set, optional): Set of rule names to use. Defaults to all rules.
+            * `base_dir` (str, optional): directory to use to download package to. If not specified, a temporary folder is created and cleaned up automatically. If not specified, the provided directory is not removed after the scan.
+            * `write_package_info` (bool, default False): if set to true, the result of the PyPI metadata API is written to a json file
 
         Raises:
             Exception: Analyzer exception

--- a/guarddog/scanners/package_scanner.py
+++ b/guarddog/scanners/package_scanner.py
@@ -90,7 +90,7 @@ class PackageScanner(Scanner):
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             # Directory to download compressed and uncompressed package
-            return self._scan_remote(name, tmpdirname, version, rules)
+            return self._scan_remote(name, tmpdirname, version, rules, write_package_info)
 
     def download_package(self, package_name, directory, version=None) -> None:
         """Downloads the PyPI distribution for a given package and version

--- a/poetry.lock
+++ b/poetry.lock
@@ -485,7 +485,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "semgrep"
-version = "0.107.0"
+version = "0.122.0"
 description = "Lightweight static analysis for many languages. Find bug variants with patterns that look like source code."
 category = "main"
 optional = false
@@ -505,10 +505,14 @@ peewee = ">=3.14,<4.0"
 python-lsp-jsonrpc = ">=1.0.0,<1.1.0"
 requests = ">=2.22,<3.0"
 "ruamel.yaml" = ">=0.16.0,<0.18"
+tomli = ">=2.0.1,<2.1.0"
 tqdm = ">=4.46,<5.0"
 typing-extensions = ">=4.2,<5.0"
 urllib3 = ">=1.26,<2.0"
 wcmatch = ">=8.3,<9.0"
+
+[package.extras]
+experiments = ["jsonnet (>=0.18,<1.0)"]
 
 [[package]]
 name = "six"
@@ -609,8 +613,8 @@ test = ["websockets"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.10, <4"
-content-hash = "e873e8f4a01c7694c53abc7954920de1e33e54072478a105e52954ef44b81d54"
+python-versions = ">=3.9, <4"
+content-hash = "22667f3d22e91d7ad659fea68e700b90fddc7595914971f3ab78a0c052746ec6"
 
 [metadata.files]
 atomicwrites = [
@@ -865,10 +869,10 @@ requests = [
     {file = "ruamel.yaml.clib-0.2.6.tar.gz", hash = "sha256:4ff604ce439abb20794f05613c374759ce10e3595d1867764dd1ae675b85acbd"},
 ]
 semgrep = [
-    {file = "semgrep-0.107.0-cp37.cp38.cp39.py37.py38.py39-none-any.whl", hash = "sha256:51dc4813e2304efa9811d89c81614b6076a6d16f6ca56f19f672898d451946b5"},
-    {file = "semgrep-0.107.0-cp37.cp38.cp39.py37.py38.py39-none-macosx_10_14_x86_64.whl", hash = "sha256:2902ca1825fa2a17a57b5b8fbe0828c4c714bbe82dff7bc5f415cd876f58d715"},
-    {file = "semgrep-0.107.0-cp37.cp38.cp39.py37.py38.py39-none-macosx_11_0_arm64.whl", hash = "sha256:202a3cc52e96b6603d22f3d5629e6f654008d53ab32613dbc9a8521be6cc42b9"},
-    {file = "semgrep-0.107.0.tar.gz", hash = "sha256:f357b650dcc517671286aa6df4b3e7a2eb1f12ca178edd6c18b9c8eeea3ca135"},
+    {file = "semgrep-0.122.0-cp37.cp38.cp39.py37.py38.py39-none-any.whl", hash = "sha256:c7002b9aba97deb6677f4cabfa5dcc8faef2808ce6a6f28ecdd70cd8e90b01b5"},
+    {file = "semgrep-0.122.0-cp37.cp38.cp39.py37.py38.py39-none-macosx_10_14_x86_64.whl", hash = "sha256:e3fb9956e2bb926cfeff52deafe4cec24d5f1e91fe6d3fc4f81e86ec452b2ad5"},
+    {file = "semgrep-0.122.0-cp37.cp38.cp39.py37.py38.py39-none-macosx_11_0_arm64.whl", hash = "sha256:6116391b0c8c87581d9d72113702b6f8c2938d799cdae7d71a845ec89249566c"},
+    {file = "semgrep-0.122.0.tar.gz", hash = "sha256:a4c7400eb8bec9fe8df25520d1ffcb5d78b87c73dc654f1c2aec1195789bc611"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,9 @@ license = "Apache 2.0"
 guarddog = "guarddog.cli:cli"
 
 [tool.poetry.dependencies]
-python = ">=3.10, <4"
+python = ">=3.9, <4"
 docker = "==6.0.0b1"
-semgrep = "==0.107.0"
+semgrep = "==0.122.0"
 requests = "==2.28.1"
 tqdm = "==4.64.0"
 python-dotenv = "==0.20.0"


### PR DESCRIPTION
This PR includes a few change needed to make GuardDog run smoothly in aws lambda

Make scan_remote method easy to use programatically:
* move error handling to CLI interface code
* expose the PackageScanner class publicly
* allow override of temporary directory location
* allow keeping the output of the metadata API call

MISC:
* update semgrep
* downgrade lower supported Python version to 3.9
