### PR TITLE
Ignore packages that don't exist in PyPI (closes #78)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,8 @@ jobs:
       run: make test-semgrep-rules
     - name: Python unit tests
       run: make test-metadata-rules
+    - name: Core unit tests
+      run: make test-core
 
   docker-build:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
-.PHONY: test test-semgrep-rules test-metadata-rules
+.PHONY: test test-semgrep-rules test-metadata-rules test-core
 
-test: test-semgrep-rules test-metadata-rules
+test: test-semgrep-rules test-metadata-rules test-core
 
 test-semgrep-rules:
 	semgrep --metrics off --quiet --test --config guarddog/analyzer/sourcecode tests/analyzer/sourcecode
 
 test-metadata-rules:
-	python -m pytest
+	python -m pytest tests/analyzer/metadata
+
+test-core:
+	python -m pytest tests/core

--- a/guarddog/scanners/project_scanner.py
+++ b/guarddog/scanners/project_scanner.py
@@ -100,13 +100,15 @@ class RequirementsScanner(Scanner):
         try:
             for requirement in pkg_resources.parse_requirements(sanitized_requirements):
                 valid_versions = None
+                project_exists_on_pypi = True
                 for spec in requirement.specs:
                     qualifier, version = spec
 
                     try:
                         available_versions = versions(requirement.project_name)
                     except Exception:
-                        sys.stderr.write(f"Package {requirement.project_name} not on PyPI")
+                        sys.stderr.write(f"Package {requirement.project_name} not on PyPI\n")
+                        project_exists_on_pypi = False
                         continue
 
                     used_versions = None
@@ -142,7 +144,8 @@ class RequirementsScanner(Scanner):
                     else:
                         valid_versions = valid_versions & used_versions
 
-                dependencies[requirement.project_name] = valid_versions
+                if project_exists_on_pypi:
+                    dependencies[requirement.project_name] = valid_versions
         except Exception as e:
             sys.stderr.write(f"Received error {str(e)}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,5 +59,6 @@ filterwarnings = [
 ]
 
 testpaths = [
-    "tests/analyzer/metadata"
+    "tests/analyzer/metadata",
+    "tests/core"
 ]

--- a/tests/core/test_requirements_scanner.py
+++ b/tests/core/test_requirements_scanner.py
@@ -5,5 +5,4 @@ from guarddog.scanners.project_scanner import RequirementsScanner
 def test_requirements_scanner_on_non_existing_package():
     scanner = RequirementsScanner()
     result = scanner.parse_requirements(["not-a-real-package==1.0.0"])
-    print(result)
     assert "not-a-real-package" not in result

--- a/tests/core/test_requirements_scanner.py
+++ b/tests/core/test_requirements_scanner.py
@@ -1,0 +1,9 @@
+from guarddog.scanners.project_scanner import RequirementsScanner
+
+
+# Regression test for https://github.com/DataDog/guarddog/issues/78
+def test_requirements_scanner_on_non_existing_package():
+    scanner = RequirementsScanner()
+    result = scanner.parse_requirements(["not-a-real-package==1.0.0"])
+    print(result)
+    assert "not-a-real-package" not in result


### PR DESCRIPTION
When scanning requirements.txt files, we shouldn't crash on packages that don't exist on PyPI. See also #78 