### PR TITLE
Handle requirement file parsing errors

### DIFF
--- a/guarddog/scanners/project_scanner.py
+++ b/guarddog/scanners/project_scanner.py
@@ -2,12 +2,11 @@ import functools
 import os
 import re
 import sys
-from pprint import pprint
+from typing import List
 
 import pathos
 import pkg_resources
 import requests
-from packaging.requirements import InvalidRequirement
 
 from guarddog.scanners.package_scanner import PackageScanner
 from guarddog.scanners.scanner import Scanner
@@ -69,7 +68,7 @@ class RequirementsScanner(Scanner):
 
         return sanitized_lines
 
-    def parse_requirements(self, requirements) -> dict:
+    def parse_requirements(self, requirements: List[str]) -> dict:
         """
         Parses requirements.txt specification and finds all valid
         versions of each dependency

--- a/tests/core/test_requirements_scanner.py
+++ b/tests/core/test_requirements_scanner.py
@@ -1,8 +1,26 @@
+import pkg_resources
+
 from guarddog.scanners.project_scanner import RequirementsScanner
 
 
 # Regression test for https://github.com/DataDog/guarddog/issues/78
 def test_requirements_scanner_on_non_existing_package():
     scanner = RequirementsScanner()
-    result = scanner.parse_requirements(["not-a-real-package==1.0.0"])
+    result = scanner.parse_requirements(["not-a-real-package==1.0.0", "flask==2.2.2"])
     assert "not-a-real-package" not in result
+    assert "flask" in result
+
+
+# Regression test for
+def test_requirements_scanner_on_git_url_packages():
+    scanner = RequirementsScanner()
+    result = scanner.parse_requirements([
+        "flask==2.2.2",
+        "http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl",
+        "guarddog @ git+https://github.com/DataDog/guarddog.git",
+        "git+https://github.com/DataDog/guarddog.git"
+    ])
+    assert "guarddog" in result
+    assert "flask" in result
+    assert len(result) == 2
+

--- a/tests/core/test_requirements_scanner.py
+++ b/tests/core/test_requirements_scanner.py
@@ -4,14 +4,14 @@ from guarddog.scanners.project_scanner import RequirementsScanner
 
 
 # Regression test for https://github.com/DataDog/guarddog/issues/78
-def test_requirements_scanner_on_non_existing_package():
+def test_requirements_scanner():
     scanner = RequirementsScanner()
     result = scanner.parse_requirements(["not-a-real-package==1.0.0", "flask==2.2.2"])
-    assert "not-a-real-package" not in result
+    assert "not-a-real-package" not in result  # ignoring non existing packages
     assert "flask" in result
 
 
-# Regression test for
+# Regression test for https://github.com/DataDog/guarddog/issues/88
 def test_requirements_scanner_on_git_url_packages():
     scanner = RequirementsScanner()
     result = scanner.parse_requirements([


### PR DESCRIPTION
Make GuardDog ignore lines in requirements that we can't parse and log a proper warning

closes #88