### PR TITLE
pyproject.toml: Add repository url

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ description = "GuardDog is a CLI tool to Identify malicious PyPI packages"
 authors = ["Ellen Wang", "Christophe Tafani-Dereeper"]
 license = "Apache-2.0"
 readme = "pypi.rst"
+repository = "https://github.com/DataDog/guarddog"
 version = "0.0.0"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
Add missing project link to PyPi.