### PR TITLE
Heuristic: identify usage of globals and __import__ (closes #62)

### DIFF
--- a/guarddog/analyzer/sourcecode/code-execution.yml
+++ b/guarddog/analyzer/sourcecode/code-execution.yml
@@ -95,6 +95,15 @@ rules:
         - pattern: os.spawnvpe($ARG1, ...)
         - pattern: os.posix_spawn($ARG1, ...)
         - pattern: os.posix_spawnp($ARG1, ...)
+
+        # Usage of builtins + base64 decode
+        - pattern: __import__('builtins').exec($ARG1)
+
+        # Usage of globals to call eval
+        - pattern-either:
+            - pattern: globals()['eval']($ARG1)
+            - pattern: globals()['\x65\x76\x61\x6c']($ARG1) # that's "eval" in hexadecimal
+
       - metavariable-pattern:
           metavariable: $ARG1
           patterns:

--- a/tests/analyzer/sourcecode/code-execution.py
+++ b/tests/analyzer/sourcecode/code-execution.py
@@ -165,3 +165,12 @@ if line.startswith("DANGEROUS"):
     eval(line)
     # ruleid: code-execution
     eval("print('bar')")
+
+
+# ruleid: code-execution
+__import__('builtins').exec(__import__('builtins').compile(__import__('base64').b64decode("foo"),'<string>','exec'))
+
+
+from builtins import *;
+# ruleid: code-execution
+OOO0O0OOOOO000oOo0oOoOo0,llIIlIlllllIlIlIlll,Oo000O0OO0oO0oO00oO0oO0O,WXWXXWWXXWXWXWWXXXWXXWX,XWWWWXXXXWWWWWXXWWX=(lambda SS2S222S22SS22S22S:SS2S222S22SS22S22S(__import__('\x7a\x6c\x69\x62'))),(lambda SS2S222S22SS22S22S:globals()['\x65\x76\x61\x6c'](globals()['\x63\x6f\x6d\x70\x69\x6c\x65'](globals()['\x73\x74\x72'])))


### PR DESCRIPTION
see #62, this was used in malware and unlikely to be used by legitimate software.

drawback: this rule only scans setup.py so we might want on the long term to create a new rule just for these that scans all files