### PR TITLE
Fixing False Positives and Duplicate Errors in the Typosquatting Algorithm

### DIFF
--- a/guarddog/analyzer/metadata/typosquatting.py
+++ b/guarddog/analyzer/metadata/typosquatting.py
@@ -216,7 +216,7 @@ class TyposquatDetector(Detector):
             typosquatting from
         """
 
-        typosquatted = []
+        typosquatted = set()
 
         # Get permuted typosquats for normalized and confused names
         normalized_name = package_name.lower().replace("_", "-")
@@ -229,16 +229,16 @@ class TyposquatDetector(Detector):
                 return []
 
             if self._is_length_one_edit_away(normalized_name, normalized_popular_package):
-                typosquatted.append(popular_package)
+                typosquatted.add(popular_package)
 
             alternate_popular_names = self._get_confused_forms(normalized_popular_package)
             swapped_popular_names = self._generate_permutations(normalized_popular_package)
 
             for name in alternate_popular_names + swapped_popular_names:
                 if self._is_length_one_edit_away(normalized_name, name):
-                    typosquatted.append(normalized_popular_package)
+                    typosquatted.add(normalized_popular_package)
 
-        return typosquatted
+        return list(typosquatted)
 
     def detect(self, package_info) -> tuple[bool, Optional[str]]:
         """

--- a/guarddog/analyzer/metadata/typosquatting.py
+++ b/guarddog/analyzer/metadata/typosquatting.py
@@ -221,12 +221,12 @@ class TyposquatDetector(Detector):
         # Get permuted typosquats for normalized and confused names
         normalized_name = package_name.lower().replace("_", "-")
 
+        if normalized_name in self.popular_packages:
+            return []
+
         # Go through popular packages and find length one edit typosquats
         for popular_package in self.popular_packages:
             normalized_popular_package = popular_package.lower().replace("_", "-")
-
-            if normalized_name == popular_package:
-                return []
 
             if self._is_length_one_edit_away(normalized_name, normalized_popular_package):
                 typosquatted.add(popular_package)

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,3 +54,5 @@ ujson==5.4.0 ; python_version >= "3.10" and python_version < "4"
 urllib3==1.26.11 ; python_version >= "3.10" and python_version < "4"
 wcmatch==8.4 ; python_version >= "3.10" and python_version < "4"
 websocket-client==1.3.3 ; python_version >= "3.10" and python_version < "4"
+
+packaging~=21.3

--- a/tests/analyzer/metadata/test_typosquatting.py
+++ b/tests/analyzer/metadata/test_typosquatting.py
@@ -42,3 +42,22 @@ class TestTyposquatting:
         project_info = generate_project_info("name", name)
         matches, _ = self.detector.detect(project_info)
         assert not matches
+
+    def test_no_duplicate_errors(self):
+        """
+        Verify that a package with a typo in the name only reports 1 error
+
+        Regression test for https://github.com/DataDog/guarddog/issues/71
+        """
+        result = self.detector.get_typosquatted_package("pdfminer.sid")
+        assert len(result) == 1
+
+    def test_normalize_names(self):
+        """
+        Verify that a package with 1 or more dots(.), hyphens(-) or underscore(_) gets normalized
+        to avoid false positives
+
+        Regression test for https://github.com/DataDog/guarddog/issues/71
+        """
+        result = self.detector.get_typosquatted_package("pdfminer...---___six")
+        assert len(result) == 0


### PR DESCRIPTION
# Problem
- If a package has a dot in the name and it is a 'top package', then the typosquatting algorithm reports an error 
- The typosquatting algorithm may report 2 errors for the same package

# Changes
- Normalize package names according to [PEP 503](https://peps.python.org/pep-0503/) and [PEP 426](https://peps.python.org/pep-0426) using [packaging](https://packaging.pypa.io/en/stable/index.html) -- the same library used by pip
- Typosquatting algorithm now only returns a list of unique 'malicious' packages
- Exit early from the typosquat algorithm if a package is in the 'top packages' list
- Fixed constructor call
- Minor refactoring

# Tests
- `TestTyposquatting.test_no_duplicate_errors`
  - Verify that a package with a typo in the name only reports 1 error
- `TestTyposquatting.test_normalize_names`
  - Verify that a package with 1 or more dots(.), hyphens(-) or underscore(_) gets normalized to avoid false positives

# Issues
- Fixes #71