### PR TITLE
chores: Bump certify version to fix GHSA-43fp-rhv2-5gv8

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -30,7 +30,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "certifi"
-version = "2022.9.24"
+version = " 2022.12.07"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false


### PR DESCRIPTION
```
$ osv-scanner --lockfile poetry.lock
╭─────────────┬───────────┬──────────────────┬───────────┬───────────────────────────────────────────────────╮
│ SOURCE      │ ECOSYSTEM │ AFFECTED PACKAGE │ VERSION   │ OSV URL (ID IN BOLD)                              │
├─────────────┼───────────┼──────────────────┼───────────┼───────────────────────────────────────────────────┤
│ poetry.lock │ PyPI      │ certifi          │ 2022.9.24 │ https://osv.dev/vulnerability/GHSA-43fp-rhv2-5gv8 │
╰─────────────┴───────────┴──────────────────┴───────────┴───────────────────────────────────────────────────╯
```