### PR TITLE
New rule for "silent execution" of popen based on Pytorch attack. Some cleanup of processing whl files

### DIFF
--- a/guarddog/analyzer/sourcecode/code-execution.yml
+++ b/guarddog/analyzer/sourcecode/code-execution.yml
@@ -1,7 +1,7 @@
 # Only searches in setup.py to reduce false positives!
 
 rules:
-  - id: code-execution
+  - id: code-execution in setup.py
     languages:
       - python
     message: 'setup.py file executing code'

--- a/guarddog/analyzer/sourcecode/code-execution.yml
+++ b/guarddog/analyzer/sourcecode/code-execution.yml
@@ -1,7 +1,7 @@
 # Only searches in setup.py to reduce false positives!
 
 rules:
-  - id: code-execution in setup.py
+  - id: code-execution
     languages:
       - python
     message: 'setup.py file executing code'

--- a/guarddog/analyzer/sourcecode/silent-popen.yml
+++ b/guarddog/analyzer/sourcecode/silent-popen.yml
@@ -1,6 +1,6 @@
 rules:
 - id: silent_popen_binary_execution
-  pattern: subprocess.$FUNC(..., stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, stdin=subprocess.DEVNULL)
+  pattern: subprocess.$FUNC(..., stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, stdin=subprocess.DEVNULL, ...)
   message: subprocess called to a file while silencing stdout, stderr and stdin to /dev/null
   languages: 
     - python

--- a/guarddog/analyzer/sourcecode/silent-popen.yml
+++ b/guarddog/analyzer/sourcecode/silent-popen.yml
@@ -1,0 +1,8 @@
+rules:
+- id: silent_popen_binary_execution
+  pattern: subprocess.$FUNC(..., stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, stdin=subprocess.DEVNULL)
+  message: subprocess called to a file while silencing stdout, stderr and stdin to /dev/null
+  languages: 
+    - python
+  severity: WARNING
+

--- a/guarddog/scanners/package_scanner.py
+++ b/guarddog/scanners/package_scanner.py
@@ -3,8 +3,6 @@ import os
 import tempfile
 
 import requests
-import tarsafe  # type:ignore
-import zipfile
 
 from guarddog.analyzer.analyzer import Analyzer
 from guarddog.scanners.scanner import Scanner

--- a/guarddog/scanners/package_scanner.py
+++ b/guarddog/scanners/package_scanner.py
@@ -4,6 +4,7 @@ import tempfile
 
 import requests
 import tarsafe  # type:ignore
+import zipfile
 
 from guarddog.analyzer.analyzer import Analyzer
 from guarddog.scanners.scanner import Scanner
@@ -42,9 +43,9 @@ class PackageScanner(Scanner):
             rules = set(rules)
 
         if os.path.exists(path):
-            if path.endswith('.tar.gz'):
+            if path.endswith('.tar.gz') or path.endswith('.whl') or path.endswith('.zip'):
                 with tempfile.TemporaryDirectory() as tmpdirname:
-                    tarsafe.open(path).extractall(tmpdirname)
+                    safe_extract(path, tmpdirname)
                     return self.analyzer.analyze_sourcecode(tmpdirname, rules=rules)
             elif os.path.isdir(path):
                 return self.analyzer.analyze_sourcecode(path, rules=rules)

--- a/guarddog/utils/archives.py
+++ b/guarddog/utils/archives.py
@@ -15,7 +15,7 @@ def safe_extract(source_archive: str, target_directory: str) -> None:
     """
     if source_archive.endswith('.tar.gz'):
         tarsafe.open(source_archive).extractall(target_directory)
-    elif source_archive.endswith('.zip'):
+    elif source_archive.endswith('.zip') or source_archive.endswith('.whl'):
         with zipfile.ZipFile(source_archive, 'r') as zip:
             for file in zip.namelist():
                 # Note: zip.extract cleans up any malicious file name such as directory traversal attempts


### PR DESCRIPTION
On Dec 31 2022, pytorch maintainers published [this](https://pytorch.org/blog/compromised-nightly-dependency/) post detailing a supply chain attack. 

It primarily focused on using dependency confusion on how `pip` installs packages in a particular order. An internal package was used (triton), but someone registered triton on pypi. 

It was a copypasta of triton with one additional `__init__.py` that dropped a binary and executed it.

[Triage](https://tria.ge/230101-wq65vafe4w/behavioral1) analysis here

This P/R adds a rule that "alerts" on this attack by looking for `subprocess.FUNC(...,)` with arguments that make it a "silent execution" to reduce false positives. I successfully tested this on the malicious package in the post and it found the malicious code!

I thought our code execution code would catch this, but we scoped it to `setup.py` to reduce false positives. I think /dev/nulling std* is a very specific pattern for malware, so I added it here.

![image](https://user-images.githubusercontent.com/1242396/210181589-53340030-a29b-4e72-b185-0d223a2a9b3c.png)
