### PR TITLE
NPM heuristic to identify pre/post-install hooks

### DIFF
--- a/guarddog/analyzer/sourcecode/__init__.py
+++ b/guarddog/analyzer/sourcecode/__init__.py
@@ -26,5 +26,5 @@ for file_name in rule_file_names:
                 match(lang):
                     case "python":
                         SOURCECODE_RULES[ECOSYSTEM.PYPI].add(rule["id"])
-                    case "javascript" | "typescript":
+                    case "javascript" | "typescript" | "json":
                         SOURCECODE_RULES[ECOSYSTEM.NPM].add(rule["id"])

--- a/guarddog/analyzer/sourcecode/npm-install-script.yml
+++ b/guarddog/analyzer/sourcecode/npm-install-script.yml
@@ -1,0 +1,22 @@
+rules:
+- id: npm-install-script
+  message: The package.json has a script automatically running when the package is installed
+  patterns:
+  - pattern-inside: |
+        "scripts": {...}
+  - pattern-either:
+    - pattern: |
+        "preinstall": "..."
+    - pattern: |
+        "install": "..."
+    - pattern: |
+        "postinstall": "..."
+    - pattern: |
+        "prepare": "..."
+  languages:
+    - json
+  paths:
+    include:
+      - "*/package.json"
+      - "*/npm-install-script.json" # unit test
+  severity: WARNING

--- a/tests/analyzer/sourcecode/npm-install-script.json
+++ b/tests/analyzer/sourcecode/npm-install-script.json
@@ -1,0 +1,13 @@
+{
+  "name": "my-package",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    // ruleid: npm-install-script
+    "postinstall": "echo Running malicious code"
+  },
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
Sample output:

![image](https://user-images.githubusercontent.com/136675/214553604-c659e4e1-2d03-4f76-a1a4-7302990fa9d5.png)

From https://arxiv.org/pdf/2112.10165.pdf:

> We found 2.2% (33,249) of packages use install scripts, indicat- ing that 97.8% of packages may follow npm recommendation of not using the install script as best security practices.

> We found 93.9% (3,412) of malicious packages had atleast one install scripts, indicating that malicious attackers use install scripts frequently.