### PR TITLE
Consider 'guarddog xxx scan .' a local target (fixes #175)

### DIFF
--- a/guarddog/scanners/scanner.py
+++ b/guarddog/scanners/scanner.py
@@ -307,6 +307,7 @@ class PackageScanner(Scanner):
 
         try:
             safe_extract(archive_path, target_path)
+            log.debug(f"Successfully extracted files to {target_path}")
         finally:
             log.debug(f"Removing temporary archive file {archive_path}")
             os.remove(archive_path)

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -8,6 +8,7 @@ def test_is_local_target():
     assert guarddog.cli.is_local_target("/tmp/foo")
     assert guarddog.cli.is_local_target("./foo")
     assert guarddog.cli.is_local_target("../foo")
+    assert guarddog.cli.is_local_target(".")
     assert not guarddog.cli.is_local_target("foo")
 
     with unittest.mock.patch('os.path.exists') as mock:


### PR DESCRIPTION
Running `guarddog npm scan .` should scan the local current directory, instead of scanning a remote package called `.`