### PR TITLE
Detect when join(...) is used in exec/eval/... functions

### DIFF
--- a/guarddog/analyzer/sourcecode/exec-base64.yml
+++ b/guarddog/analyzer/sourcecode/exec-base64.yml
@@ -48,6 +48,8 @@ rules:
       - pattern-either:
           - pattern: |
               "...".decode(...)
+          - pattern: |
+              "...".join(...)
           - pattern: base64.b64decode("...")
           - pattern: base64.b64decode(...)
           - pattern: decode("...")

--- a/tests/analyzer/sourcecode/exec-base64.py
+++ b/tests/analyzer/sourcecode/exec-base64.py
@@ -98,3 +98,11 @@ exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('aW
 
 # ruleid: exec-base64
 import marshal,zlib;exec(marshal.loads(zlib.decompress(b'x\x9cM...`;')))
+
+""" RULEID: using the join function execute a base64 encoded string
+"""
+# ruleid: exec-base64
+exec(''.join([y[0] for x in [x for x in base64.b64decode( ('TSUmPCwrKCEvLCQnLypNJ3AnL3IvLCQnLypEJC').encode('ascii') ).decode('ascii')] for y in [[x[0], x[1]] for x in {'\t': 'e', '\n': 'M', ' ': '!', '!': 'u', '@': ':', '~': ')', '`': '#', '#': '9', '$': 'J', '%': '`', '^': 'x', '&': 'b', '*': '2', '(': 'r', ')': ' ', '_': '[', '=': '.', '-': 'R', '+': 'K', '{': 'n', '}': '-', '|': 'm', '\\': 'C', '[': 'Z', ']': 'j', ':': '3', ';': 'z', '"': '~', "'": 'c', ',': 'g', '.': 'D', '/': 'L', '?': '1', '>': '7', '<': '|', '0': 'q', '1': 'G', '2': 'd', '3': 'X', '4': '"', '5': '\t', '6': 'N', '7': '_', '8': '6', '9': 'i', 'a': 'O', 'b': '^', 'c': '/', 'd': '$', 'e': "'", 'f': '0', 'g': 'V', 'h': 'T', 'i': '%', 'j': 'H', 'k': '=', 'l': 'l', 'm': '&', 'n': '?', 'o': ',', 'p': '<', 'q': 'a', 'u': 'F', 'r': '+', 's': '*', 't': '(', 'v': '@', 'w': 'o', 'x': 'p', 'y': 'A', 'z': '4', 'A': 'v', 'B': 'I', 'C': 'f', 'D': 'P', 'E': 'k', 'F': 's', 'G': '5', 'H': '8', 'I': 'U', 'J': ']', 'K': 'h', 'L': 'W', 'M': 'B', 'N': '>', 'O': 'E', 'P': '\\', 'Q': 'y', 'U': 'S', 'R': 't', 'S': '}', 'T': '{', 'V': 'Y', 'W': '\n', 'X': ';', 'Y': 'w', 'Z': 'Q'}.items()] if x == y[1]]))
+
+# ruleid: exec-base64
+exec(''.join(base64.b64decode("YWFh").decode()))


### PR DESCRIPTION
[Related issue](https://github.com/DataDog/guarddog/issues/64)
Detect when a Join function is used in an Exec / eval... functions.

This will also catch other types of obfuscation using loop to evade detection