### PR TITLE
Optimize docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.devcontainer/*
+.vscode/*
+.*
+tests/*
+Dockerfile
+docker-compose*
+coverage.xml
+dist/*
+htmlcov/*

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
-          context: .
           push: true
           build-args: |
             VERSION=${{ github.ref_name }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -8,6 +8,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: datadog/guarddog
+  DOCKER_BUILDKIT: 1
 
 permissions:
   contents: read

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -8,7 +8,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: datadog/guarddog
-  DOCKER_BUILDKIT: 1
 
 permissions:
   contents: read
@@ -20,20 +19,18 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2.5.0
-        with:
-          fetch-depth: 0
-
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3.2.0
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: datadog/guarddog
+
 jobs:
 
   type-check:
@@ -106,9 +110,14 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2.5.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
         with:
-          fetch-depth: 0
-      - name: Build local Docker image
-        run: docker build .
+          push: false
+          build-args: |
+            VERSION=${{ github.ref_name }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,5 +119,3 @@ jobs:
           push: false
           build-args: |
             VERSION=${{ github.ref_name }}
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,27 @@
-FROM python:3.10.9-alpine3.17 AS builder
+FROM python:3.10-slim-bullseye AS base
 LABEL org.opencontainers.image.source="https://github.com/DataDog/guarddog/"
-RUN mkdir /app
-# gcc and musl-dev needed for the pip install
-RUN apk add --update gcc musl-dev g++ libgit2-dev libffi-dev
-ADD . /app
-WORKDIR /app
-RUN pip install --no-cache-dir -r requirements.txt
 
-#FROM cgr.dev/chainguard/python:latest AS runner
-#COPY --from=builder /app /app
-#COPY --from=builder /usr/local/lib/python3.10/site-packages /app/site-packages
-#ENV PYTHONPATH=/app/site-packages
+RUN addgroup --system --gid 1000 app \
+    && adduser --system --shell /bin/bash --uid 1000 --ingroup app app
+
+RUN mkdir /app
 WORKDIR /app
-ENTRYPOINT ["python", "-m", "guarddog"]
+
+
+FROM base as builder
+# only copy source for build
+COPY . /app
+# install any build time deps + Python deps
+RUN --mount=type=cache,mode=0755,id=pip,target=/root/.cache/pip \
+    # install python deps
+    pip install --root-user-action=ignore -r requirements.txt \
+    # install package
+    && pip install --root-user-action=ignore .
+
+
+FROM base as app
+# copy built deps from builder
+COPY --from=builder /usr/local/bin/ /usr/local/bin/
+COPY --from=builder /usr/local/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages
+USER app
+ENTRYPOINT ["guarddog"]


### PR DESCRIPTION
* Adds .dockerignore to prevent uncessary files from being copied into the container
* Removes the patch version pin from the container
    * Pinning to 3.10 means you can get patch versions for security fixes/etc., pinning to 3.10.9 means you cannot
    * [3.10.12](https://www.python.org/downloads/release/python-31012/) was a security release
* Use [RUN caching](https://docs.docker.com/build/cache/#use-the-dedicated-run-cache) for pip cache
    * This requires updating all of the docker build steps in the GitHub Actions workflows to using buildkit as well since this is a buildkit feature
* Do not run container as root, this is a general best practice
* Adds build layer so build time deps are not kept in image (almost 50% reduction in image size)
* Change image from Alpine to Debian*

`*` Alpine to Debian note:

tldr; Debian is overall better for Python and it is the best choice if you want to optimize for build times, but will add ~80MB to your image builds.

Alpine is often recommended for containers, but for Python it is generally not a great solution. It can provide slightly smaller images, but Python is already pretty large, this does not lead to the same level of size savings as it does for other languages, such as Go. It is usually right around ~80 MB for Python to compared the Alpine images to the Debian slim images. The biggest cost saving for size is going to be actually using a build layer and not keeping the build only deps in the final image.

Additionally, building [Alpine/musl specific wheels is relatively new](https://peps.python.org/pep-0656/) and most of the requirements used by this application do not build them. So, using Alpine drastically increases the build time of the container. Using Debian instead allows re-using all of the pre-built wheels.

Here is a comparison below. I optimized the container using both Alpine and Debian:

| Base | Build Time | Size | Percent "wasted" |
| ----- | ----------- | ----- | ------------------ |
| Alpine | 35.4s | 208 MB | 26.0% |
| Debian | 13.9s | 298 MB | 43.8% | 

* Build times are average of 3 (with 1 warmup to create pip cache). 
* Percent "wasted" is how much of the image is _not_ from the final copy step that moves the build deps over from the build image.

You can instead merge [the alterative Alpine version of this PR](https://github.com/DataDog/guarddog/pull/252), but I was also thinking of adding an arm64 image build for Docker as well. If I do that, the Alpine build times will suffer even more due to needing to virtualize QEMU to build the arm64 target.

Example using Github Actions Workflow runs (-37 seconds build time):

* Alpine: https://github.com/DataDog/guarddog/actions/runs/5338093490/jobs/9674987672?pr=252
* Debian: https://github.com/DataDog/guarddog/actions/runs/5335714532/jobs/9669348415