### PR TITLE
Build multi-platform images

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -26,12 +26,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
+          platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
             VERSION=${{ github.ref_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,12 +110,16 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
+          platforms: linux/amd64,linux/arm64
           push: false
           build-args: |
             VERSION=${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10-alpine3.17 AS base
 LABEL org.opencontainers.image.source="https://github.com/DataDog/guarddog/"
 
-RUN --mount=type=cache,mode=0755,id=apk,target=/var/cache/apk \
+RUN --mount=type=cache,mode=0755,id=apk-${TARGETARCH},target=/var/cache/apk \
     apk add --update libgit2 libffi
 RUN addgroup --system --gid 1000 app \
     && adduser --system --shell /bin/bash --uid 1000 --ingroup app app
@@ -14,9 +14,9 @@ FROM base as builder
 # only copy source for build
 COPY . /app
 # install any build time deps + Python deps
-RUN --mount=type=cache,mode=0755,id=apk,target=/var/cache/apk \
+RUN --mount=type=cache,mode=0755,id=apk-${TARGETARCH},target=/var/cache/apk \
     apk add --update gcc musl-dev g++ libgit2-dev libffi-dev
-RUN --mount=type=cache,mode=0755,id=pip,target=/root/.cache/pip \
+RUN --mount=type=cache,mode=0755,id=pip-${TARGETARCH},target=/root/.cache/pip \
     # install python deps
     pip install --root-user-action=ignore -r requirements.txt \
     # install package

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.10-alpine3.17 AS base
 LABEL org.opencontainers.image.source="https://github.com/DataDog/guarddog/"
 
+# automatically provided by buildkit
 ARG TARGETARCH
 
 RUN --mount=type=cache,mode=0755,id=apk-$TARGETARCH,target=/var/cache/apk \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM python:3.10-alpine3.17 AS base
 LABEL org.opencontainers.image.source="https://github.com/DataDog/guarddog/"
 
-RUN --mount=type=cache,mode=0755,id=apk-${TARGETARCH},target=/var/cache/apk \
+ARG TARGETARCH
+
+RUN --mount=type=cache,mode=0755,id=apk-$TARGETARCH,target=/var/cache/apk \
     apk add --update libgit2 libffi
 RUN addgroup --system --gid 1000 app \
     && adduser --system --shell /bin/bash --uid 1000 --ingroup app app
@@ -14,9 +16,9 @@ FROM base as builder
 # only copy source for build
 COPY . /app
 # install any build time deps + Python deps
-RUN --mount=type=cache,mode=0755,id=apk-${TARGETARCH},target=/var/cache/apk \
+RUN --mount=type=cache,mode=0755,id=apk-$TARGETARCH,target=/var/cache/apk \
     apk add --update gcc musl-dev g++ libgit2-dev libffi-dev
-RUN --mount=type=cache,mode=0755,id=pip-${TARGETARCH},target=/root/.cache/pip \
+RUN --mount=type=cache,mode=0755,id=pip-$TARGETARCH,target=/root/.cache/pip \
     # install python deps
     pip install --root-user-action=ignore -r requirements.txt \
     # install package

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,6 @@
-FROM python:3.10-alpine3.17 AS base
+FROM python:3.10-slim-bullseye AS base
 LABEL org.opencontainers.image.source="https://github.com/DataDog/guarddog/"
 
-# automatically provided by buildkit
-ARG TARGETARCH
-
-RUN --mount=type=cache,mode=0755,id=apk-$TARGETARCH,target=/var/cache/apk \
-    apk add --update libgit2 libffi
 RUN addgroup --system --gid 1000 app \
     && adduser --system --shell /bin/bash --uid 1000 --ingroup app app
 
@@ -17,9 +12,7 @@ FROM base as builder
 # only copy source for build
 COPY . /app
 # install any build time deps + Python deps
-RUN --mount=type=cache,mode=0755,id=apk-$TARGETARCH,target=/var/cache/apk \
-    apk add --update gcc musl-dev g++ libgit2-dev libffi-dev
-RUN --mount=type=cache,mode=0755,id=pip-$TARGETARCH,target=/root/.cache/pip \
+RUN --mount=type=cache,mode=0755,id=pip,target=/root/.cache/pip \
     # install python deps
     pip install --root-user-action=ignore -r requirements.txt \
     # install package


### PR DESCRIPTION
Last one (for now).

Make the docker builds multi-platform and build linux/amd64 and linux/arm64 at the same time.

Note: Because the base image is Alpine, it has to compile the wheels for both platforms. Compiling for linux/arm64 over virtualization takes significantly longer (~1 minute to ~9 minutes).