### PR TITLE
Add support for site-packages

### DIFF
--- a/guarddog/scanners/scanner.py
+++ b/guarddog/scanners/scanner.py
@@ -236,9 +236,10 @@ class PackageScanner(Scanner):
                     return self.analyzer.analyze_sourcecode(tmpdirname, rules=rules)
             elif os.path.isdir(path):
                 return self.analyzer.analyze_sourcecode(path, rules=rules)
-            else:
-                raise Exception(f"Path {path} is not a directory nor an archive type supported by GuardDog.")
-        raise Exception(f"Path {path} does not exist.")
+            else:  # is a file
+                return self.analyzer.analyze_sourcecode(path, rules=rules)
+        else:
+            raise Exception(f"Path {path} does not exist.")
 
     @abstractmethod
     def download_and_get_package_info(self, directory: str, package_name: str, version=None) -> typing.Tuple[dict, str]:


### PR DESCRIPTION
This PR adds support for scanning site-packages directories

This is helpful in an event where the user wants to install packages, then scan the site-packages directory. My use case is to use pipenv to install the packages, then run guarddog against the site-packages directory generated by pipenv.

The code changes are minimal, it extends the pypi ProjectScanner.scan_local to support arbitrary files (currently only archives and directories are supported).


