### PR TITLE
support sarif output for scan

### DIFF
--- a/guarddog/analyzer/analyzer.py
+++ b/guarddog/analyzer/analyzer.py
@@ -257,6 +257,9 @@ output: {e.output}
 
             results[rule_name].append({
                 'location': location,
+                'start': result["start"],
+                'end': result["end"],
+                'path': result["path"],
                 'code': code,
                 'message': result["extra"]["message"]
             })

--- a/guarddog/reporters/sarif.py
+++ b/guarddog/reporters/sarif.py
@@ -190,9 +190,8 @@ def report_verify_sarif(package_path: str, rule_names: list[str], scan_results: 
     return json.dumps(log, indent=2)
 
 
-
 def report_scan_sarif(rule_names: list[str], scan_results: list[dict],
-                        ecosystem: ECOSYSTEM) -> str:
+                      ecosystem: ECOSYSTEM) -> str:
     rules_documentation = build_rules_help_list()
     rules = list(map(
         lambda s: get_rule(s, rules_documentation),


### PR DESCRIPTION
Fix #197 

Tested successfully in combination with #257 

PS: I think there is a bug in the output format SARIF for the `verify` command, it does not log all the errors