### PR TITLE
Fixed Sometimes Failing PyPI potentially_compromised_email_domain

### DIFF
--- a/guarddog/analyzer/metadata/npm/potentially_compromised_email_domain.py
+++ b/guarddog/analyzer/metadata/npm/potentially_compromised_email_domain.py
@@ -16,7 +16,10 @@ class NPMPotentiallyCompromisedEmailDomainDetector(PotentiallyCompromisedEmailDo
         super().__init__("npm")
 
     def get_email_addresses(self, package_info: dict) -> list[str]:
-        return list(map(lambda x: x["email"], package_info["maintainers"]))
+        if package_info.get("maintainers"):
+            return list(map(lambda x: x["email"], package_info["maintainers"]))
+        else:
+            return []
 
     def get_project_latest_release_date(self, package_info) -> Optional[datetime]:
         """

--- a/guarddog/analyzer/metadata/pypi/potentially_compromised_email_domain.py
+++ b/guarddog/analyzer/metadata/pypi/potentially_compromised_email_domain.py
@@ -19,7 +19,10 @@ class PypiPotentiallyCompromisedEmailDomainDetector(PotentiallyCompromisedEmailD
         author_email = package_info["info"]["author_email"]
         maintainer_email = package_info["info"]["maintainer_email"]
         email = author_email or maintainer_email
-        return [email]
+        if email is not None:
+            return [email]
+        else:
+            return []
 
     def get_project_latest_release_date(self, package_info) -> Optional[datetime]:
         """


### PR DESCRIPTION
In response to this [issue](https://github.com/DataDog/guarddog/issues/258), fixed the sometimes failing PyPI rule `potentially_compromised_email_domain`. 

The rule sometimes fails because the email address stored in `package_info` can be `None` and there is no check that the email_address is `None` before doing any parsing. Added a simple `None` check before returning email addresses for npm and python. Added a test for a None or null email


https://datadoghq.atlassian.net/browse/SINT-1432