### PR TITLE
Fixed Sometimes Failing PyPI repository_integrity_mismatch

### DIFF
--- a/guarddog/analyzer/metadata/pypi/repository_integrity_mismatch.py
+++ b/guarddog/analyzer/metadata/pypi/repository_integrity_mismatch.py
@@ -129,9 +129,10 @@ def find_github_candidates(package_info) -> Tuple[set[str], Optional[str]]:
                 github_urls.add(_ensure_proper_url(cd.strip()))
     best = None
     if homepage in github_urls:
-        response = requests.get(homepage)
-        if response.status_code == 200:
-            best = _ensure_proper_url(homepage)
+        if homepage is not None and isinstance(homepage, str):
+            response = requests.get(homepage)
+            if response.status_code == 200:
+                best = _ensure_proper_url(homepage)
 
     return github_urls, best
 

--- a/guarddog/analyzer/metadata/pypi/repository_integrity_mismatch.py
+++ b/guarddog/analyzer/metadata/pypi/repository_integrity_mismatch.py
@@ -255,9 +255,10 @@ class PypiIntegrityMismatchDetector(IntegrityMismatch):
         try:
             repo = pygit2.clone_repository(url=github_url, path=repo_path)
         except pygit2.GitError as git_error:
-            #Handle generic Git-related errors
+            # Handle generic Git-related errors
             raise Exception(f"Error while cloning repository {str(git_error)} with github url {github_url}")
         except Exception as e:
+            # Catch any other unexpected exceptions
             raise Exception(f"An unexpected error occured: {str(e)}.  github url {github_url}")
 
         tag_candidates = find_suitable_tags(repo, version)

--- a/guarddog/analyzer/metadata/pypi/repository_integrity_mismatch.py
+++ b/guarddog/analyzer/metadata/pypi/repository_integrity_mismatch.py
@@ -7,6 +7,7 @@ import hashlib
 import logging
 import os
 import re
+import requests
 from typing import Optional, Tuple
 
 import pygit2  # type: ignore
@@ -36,6 +37,7 @@ def find_best_github_candidate(all_candidates_and_highlighted_link, name):
     If the repository homepage is a GitHub URL, it is used in priority
     """
     candidates, best_github_candidate = all_candidates_and_highlighted_link
+
     # if the project url is a GitHub repository, we should follow this as an instruction. Users will click on it
     if best_github_candidate is not None:
         best_github_candidate = best_github_candidate.replace("http://", "https://")
@@ -109,6 +111,7 @@ def find_github_candidates(package_info) -> Tuple[set[str], Optional[str]]:
     homepage = None
 
     project_urls = infos.get("project_urls", {})
+
     # In some cases, the "project_urls" key is set, but is set to None
     if project_urls is None:
         return set(), None
@@ -126,7 +129,10 @@ def find_github_candidates(package_info) -> Tuple[set[str], Optional[str]]:
                 github_urls.add(_ensure_proper_url(cd.strip()))
     best = None
     if homepage in github_urls:
-        best = _ensure_proper_url(homepage)
+        response = requests.get(homepage)
+        if response.status_code == 200:
+            best = _ensure_proper_url(homepage)
+
     return github_urls, best
 
 
@@ -246,7 +252,13 @@ class PypiIntegrityMismatchDetector(IntegrityMismatch):
             raise Exception("no current scanning directory")
 
         repo_path = os.path.join(tmp_dir, "sources", name)
-        repo = pygit2.clone_repository(url=github_url, path=repo_path)
+        try:
+            repo = pygit2.clone_repository(url=github_url, path=repo_path)
+        except pygit2.GitError as git_error:
+            #Handle generic Git-related errors
+            raise Exception(f"Error while cloning repository {str(git_error)} with github url {github_url}")
+        except Exception as e:
+            raise Exception(f"An unexpected error occured: {str(e)}.  github url {github_url}")
 
         tag_candidates = find_suitable_tags(repo, version)
 

--- a/tests/analyzer/metadata/test_repository_integrity_mismatch.py
+++ b/tests/analyzer/metadata/test_repository_integrity_mismatch.py
@@ -21,8 +21,9 @@ def test_no_good_homepage_link():
         "Download": "UNKNOWN",
         "Homepage": "https://github.com/pypa/samplproject",
         },
+    current_info["info"]["summary"] = "https://github.com/pypa/sampleproject"
     detector = PypiIntegrityMismatchDetector()
-    match, message = detector.detect(current_info, name="sampleproject", path="")
+    match, message = detector.detect(current_info, name="mypackage", path="")
     assert not match
     assert message == "Could not find a good GitHub url in the project's description"
 

--- a/tests/analyzer/metadata/test_repository_integrity_mismatch.py
+++ b/tests/analyzer/metadata/test_repository_integrity_mismatch.py
@@ -14,6 +14,18 @@ def test_no_github_links():
     assert message == "Could not find any GitHub url in the project's description"
 
 
+def test_no_good_homepage_link():
+    current_info = deepcopy(PYPI_PACKAGE_INFO)
+    current_info["info"]["home_page"] = ""
+    current_info["info"]["project_urls"] = {
+        "Download": "UNKNOWN",
+        "Homepage": "https://github.com/pypa/samplproject",
+        },
+    detector = PypiIntegrityMismatchDetector()
+    match, message = detector.detect(current_info, name="sampleproject", path="")
+    assert not match
+    assert message == "Could not find a good GitHub url in the project's description"
+
 def test_no_good_github_links():
     current_info = deepcopy(PYPI_PACKAGE_INFO)
     current_info["info"]["home_page"] = ""


### PR DESCRIPTION
In response to [this](https://github.com/DataDog/guarddog/issues/258), fixed the sometimes failing PyPI rule repository_integrity_mismatch.

The rule sometimes failed because sometime the github URL that was found to be the best url option was not a valid url. To solve this, I added a check to see if the response code of the found best github URL was a 200. I also added a better error message if the repository cloning for pygit2 fails. Added a test as well to check for this failing scenario.

https://datadoghq.atlassian.net/browse/SINT-1432