### PR TITLE
[SINT-1536] Add new NPM metadata detector to catch dependencies fetched from URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Source code heuristics:
 |:-------------:|:---------------:|
 | shady-links | Identify when a package contains an URL to a domain with a suspicious extension |
 | obfuscation | Identify when a package uses a common obfuscation method often used by malware |
+| clipboard-access | Identify when a package reads or write data from the clipboard |
 | exfiltrate-sensitive-data | Identify when a package reads and exfiltrates sensitive data from the local system |
 | download-executable | Identify when a package downloads and makes executable a remote binary |
 | exec-base64 | Identify when a package dynamically executes base64-encoded code |
@@ -128,7 +129,7 @@ Metadata heuristics:
 | release_zero | Identify packages with an release version that's 0.0 or 0.0.0 |
 | potentially_compromised_email_domain | Identify when a package maintainer e-mail domain (and therefore package manager account) might have been compromised |
 | typosquatting | Identify packages that are named closely to an highly popular package |
-| direct_url_dependency | Identify packages with direct URL dependencies |
+| direct_url_dependency | Identify packages with direct URL dependencies. Dependencies fetched this way are not immutable and can be used to inject untrusted code or reduce the likelihood of a reproducible install. |
 
 
 <!-- END_RULE_LIST -->

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ guarddog pypi scan /tmp/triage.tar.gz
 
 # Scan a local directory, the packages need to be located in the root directory
 # For instance you have several pypi packages in ./samples/ like:
-# ./samples/package1.tar.gz ./samples/package2.zip ./samples/package3.whl 
+# ./samples/package1.tar.gz ./samples/package2.zip ./samples/package3.whl
 # FYI if a file not supported by guarddog is found you will get an error
 # Here is the command to scan a directory:
 guarddog pypi scan ./samples/
@@ -128,6 +128,7 @@ Metadata heuristics:
 | release_zero | Identify packages with an release version that's 0.0 or 0.0.0 |
 | potentially_compromised_email_domain | Identify when a package maintainer e-mail domain (and therefore package manager account) might have been compromised |
 | typosquatting | Identify packages that are named closely to an highly popular package |
+| direct_url_dependency | Identify packages with direct URL dependencies |
 
 
 <!-- END_RULE_LIST -->
@@ -230,12 +231,12 @@ flake8 guarddog --count --max-line-length=120 --statistics --exclude tests/analy
 
 ## Acknowledgments
 
-Authors: 
+Authors:
 * [Ellen Wang](https://www.linkedin.com/in/ellen-wang-4bb5961a0/)
 * [Christophe Tafani-Dereeper](https://github.com/christophetd)
 * [Vladimir de Turckheim](https://www.linkedin.com/in/vladimirdeturckheim/)
 
-Inspiration: 
+Inspiration:
 * [Backstabber’s Knife Collection: A Review of Open Source Software Supply Chain Attacks](https://arxiv.org/pdf/2005.09535)
 * [What are Weak Links in the npm Supply Chain?](https://arxiv.org/pdf/2112.10165.pdf)
 * [A Survey on Common Threats in npm and PyPi Registries](https://arxiv.org/pdf/2108.09576.pdf)

--- a/guarddog/analyzer/metadata/npm/__init__.py
+++ b/guarddog/analyzer/metadata/npm/__init__.py
@@ -1,8 +1,12 @@
 from guarddog.analyzer.metadata.npm.empty_information import NPMEmptyInfoDetector
-from guarddog.analyzer.metadata.npm.potentially_compromised_email_domain import \
-    NPMPotentiallyCompromisedEmailDomainDetector
+from guarddog.analyzer.metadata.npm.potentially_compromised_email_domain import (
+    NPMPotentiallyCompromisedEmailDomainDetector,
+)
 from guarddog.analyzer.metadata.npm.release_zero import NPMReleaseZeroDetector
 from guarddog.analyzer.metadata.npm.typosquatting import NPMTyposquatDetector
+from guarddog.analyzer.metadata.npm.direct_url_dependency import (
+    NPMDirectURLDependencyDetector,
+)
 
 NPM_METADATA_RULES = {}
 
@@ -10,7 +14,8 @@ classes = [
     NPMEmptyInfoDetector,
     NPMReleaseZeroDetector,
     NPMPotentiallyCompromisedEmailDomainDetector,
-    NPMTyposquatDetector
+    NPMTyposquatDetector,
+    NPMDirectURLDependencyDetector,
 ]
 
 for detectorClass in classes:

--- a/guarddog/analyzer/metadata/npm/direct_url_dependency.py
+++ b/guarddog/analyzer/metadata/npm/direct_url_dependency.py
@@ -1,0 +1,64 @@
+""" Direct URL Dependency Detector
+
+Detects if a package depends on direct URL dependencies
+"""
+from typing import Optional
+import re
+
+from guarddog.analyzer.metadata.detector import Detector
+
+from urllib.parse import urlparse
+
+
+github_project_pattern = re.compile(r"^([\w\-\.]+)/([\w\-\.]+)")
+
+
+class NPMDirectURLDependencyDetector(Detector):
+    """This heuristic detects packages with direct URL dependencies.
+    Dependencies fetched this way are not immutable and can be used to inject untrusted code
+    or reduce the likelihood of a reproducible install."""
+
+    def __init__(self):
+        super().__init__(
+            name="direct_url_dependency",
+            description="Identify packages with direct URL dependencies",
+        )
+
+    def detect(
+        self,
+        package_info,
+        path: Optional[str] = None,
+        name: Optional[str] = None,
+        version: Optional[str] = None,
+    ) -> tuple[bool, str]:
+        findings = []
+
+        for dep_name, dep_version in (
+            package_info.get("versions", {})
+            .get(version, {})
+            .get("dependencies", {})
+            .items()
+        ):
+            # According to npm documentation, HTTP(s) and Git are accepted URL schemes when specifying dependencies:
+            # https://docs.npmjs.com/cli/v10/configuring-npm/package-json#urls-as-dependencies
+            # https://docs.npmjs.com/cli/v10/configuring-npm/package-json#git-urls-as-dependencies
+            if urlparse(dep_version).scheme in [
+                "http",
+                "https",
+                "git",
+                "git+ssh",
+                "git+http",
+                "git+https",
+                "git+file",
+            ]:
+                findings.append(
+                    f"Dependency {dep_name} refers to a direct Git or HTTP URL {dep_version}."
+                )
+            # According to npm documentation, Github repositories are accepted when specifying dependencies:
+            # https://docs.npmjs.com/cli/v10/configuring-npm/package-json#github-urls
+            elif github_project_pattern.match(dep_version):
+                findings.append(
+                    f"Dependency {dep_name} refers to a direct Github repository {dep_version}."
+                )
+
+        return len(findings) != 0, "\n".join(findings)

--- a/guarddog/analyzer/metadata/npm/direct_url_dependency.py
+++ b/guarddog/analyzer/metadata/npm/direct_url_dependency.py
@@ -21,7 +21,9 @@ class NPMDirectURLDependencyDetector(Detector):
     def __init__(self):
         super().__init__(
             name="direct_url_dependency",
-            description="Identify packages with direct URL dependencies",
+            description="Identify packages with direct URL dependencies. \
+Dependencies fetched this way are not immutable and can be used to \
+inject untrusted code or reduce the likelihood of a reproducible install.",
         )
 
     def detect(

--- a/tests/analyzer/metadata/test_direct_url_dependency.py
+++ b/tests/analyzer/metadata/test_direct_url_dependency.py
@@ -1,0 +1,33 @@
+from copy import deepcopy
+
+import pytest
+
+from guarddog.analyzer.metadata.npm.direct_url_dependency import (
+    NPMDirectURLDependencyDetector,
+)
+from tests.analyzer.metadata.resources.sample_project_info import NPM_PACKAGE_INFO
+
+
+class TestDirectURLDependency:
+    npm_detector = NPMDirectURLDependencyDetector()
+
+    test_data = [
+        ("2.0.1", False),
+        ("http://asdf.com/asdf.tar.gz", True),
+        ("git+ssh://git@github.com:npm/cli.git#v1.0.27", True),
+        ("git+ssh://git@github.com:npm/cli#semver:^5.0", True),
+        ("git+https://isaacs@github.com/npm/cli.git", True),
+        ("git://github.com/npm/cli.git#v1.0.27", True),
+        ("expressjs/express", True),
+        ("mochajs/mocha#4727d357ea", True),
+        ("user/repo#feature\/branch", True),
+    ]
+
+    @pytest.mark.parametrize("version,expected_matches", test_data)
+    def test_npm_direct_url_dependencies(self, version, expected_matches):
+        package_info = deepcopy(NPM_PACKAGE_INFO)
+        package_info["versions"]["2.0.0"]["dependencies"]["foo"] = version
+        matches, _ = self.npm_detector.detect(
+            package_info, name="", path="", version="2.0.0"
+        )
+        assert matches == expected_matches

--- a/tests/analyzer/sourcecode/code-execution.py
+++ b/tests/analyzer/sourcecode/code-execution.py
@@ -9,7 +9,7 @@
 """
 
 
-""" OK: Executing python files to extract version information 
+""" OK: Executing python files to extract version information
 """
 # ok: code-execution
 exec(open("vapory_git/version.py").read())  # loads __version__
@@ -134,7 +134,7 @@ popen("cd %s && git init " % TEST_MODULES_ROOT)
 subprocess.check_output(["git", "describe", "--tags"]).strip()
 
 
-""" RULEID: executing bash commands 
+""" RULEID: executing bash commands
 """
 # ruleid: code-execution
 os.system('start ' + filename)

--- a/tests/analyzer/sourcecode/exec-base64.py
+++ b/tests/analyzer/sourcecode/exec-base64.py
@@ -7,7 +7,7 @@
         - Subprocess module
         - os module
         - Command module
-        
+
         Inner partitions:
             - Muliline executions with intermediate assignments
             - Including/excluding module name in function calls


### PR DESCRIPTION
This PR adds a new NPM metadata detector, checking for a package dependencies linking to URLs. 
Per NPM's documentation, git, http(s) and Github URLs are indeed supported version strings for a package:
- https://docs.npmjs.com/cli/v10/configuring-npm/package-json#urls-as-dependencies
- https://docs.npmjs.com/cli/v10/configuring-npm/package-json#git-urls-as-dependencies
- https://docs.npmjs.com/cli/v10/configuring-npm/package-json#github-urls

Dependencies fetched this way are not immutable and can be used to inject untrusted code or reduce the likelihood of a reproducible install.

It seems PyPI prevents the upload of Python packages with such links in `install_requires`. It's still possible to set them in `dependency_links` (https://setuptools.pypa.io/en/latest/deprecated/dependency_links.html) though which makes me wonder if we should add support for Python in another PR. 