### PR TITLE
Fix Sarif format regression

### DIFF
--- a/guarddog/cli.py
+++ b/guarddog/cli.py
@@ -149,7 +149,8 @@ def _verify(path, rules, exclude_rules, output_format, exit_non_zero_on_finding,
         return_value = js.dumps(results)
 
     if output_format == "sarif":
-        return_value = report_verify_sarif(path, list(rule_param), results, ecosystem)
+        sarif_rules = PYPI_RULES if ecosystem == ECOSYSTEM.PYPI else NPM_RULES
+        return_value = report_verify_sarif(path, list(sarif_rules), results, ecosystem)
 
     if output_format is not None:
         print(return_value)


### PR DESCRIPTION
This should fix the bug reported in https://github.com/DataDog/guarddog/issues/285.

The bug reason was `rule_param` can be `None` if no `rules` or `exclude_rules` are specified by the user. In this case, `list(rule_param)` fails to evaluate (you can't create a list from `None`). Instead the list of all rules for the target ecosystem should be passed to the function. 
