### PR TITLE
[SINT-1538] Check for NPM packages with a shrinkwrap file

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Metadata heuristics:
 | typosquatting | Identify packages that are named closely to an highly popular package |
 | direct_url_dependency | Identify packages with direct URL dependencies. Dependencies fetched this way are not immutable and can be used to inject untrusted code or reduce the likelihood of a reproducible install. |
 | npm_metadata_mismatch | Identify packages which have mismatches between the npm pacakge manifest and the package info |
+| npm_shrinkwrap_file | Identify packages with a npm-shrinkwrap.json file which prevents end users from updating transitive dependencies. |
 
 
 <!-- END_RULE_LIST -->

--- a/guarddog/analyzer/metadata/npm/__init__.py
+++ b/guarddog/analyzer/metadata/npm/__init__.py
@@ -8,6 +8,7 @@ from guarddog.analyzer.metadata.npm.direct_url_dependency import (
     NPMDirectURLDependencyDetector,
 )
 from guarddog.analyzer.metadata.npm.npm_metadata_mismatch import NPMMetadataMismatch
+from guarddog.analyzer.metadata.npm.npm_shrinkwrap_file import NPMShrinkwrapFile
 
 NPM_METADATA_RULES = {}
 
@@ -18,6 +19,7 @@ classes = [
     NPMTyposquatDetector,
     NPMDirectURLDependencyDetector,
     NPMMetadataMismatch,
+    NPMShrinkwrapFile,
 ]
 
 for detectorClass in classes:

--- a/guarddog/analyzer/metadata/npm/npm_shrinkwrap_file.py
+++ b/guarddog/analyzer/metadata/npm/npm_shrinkwrap_file.py
@@ -1,0 +1,26 @@
+from typing import Optional
+from pathlib import Path
+
+from guarddog.analyzer.metadata.detector import Detector
+
+class NPMShrinkwrapFile(Detector):
+    def __init__(self):
+        super().__init__(
+            name="npm_shrinkwrap_file",
+            description="Identify packages with a npm-shrinkwrap.json file which prevents end users from updating transitive dependencies."
+        )
+
+    def detect(
+            self,
+            package_info,
+            path: Optional[str] = None,
+            name: Optional[str] = None,
+            version: Optional[str] = None,
+            ) -> tuple[bool, Optional[str]]:
+        if path is None:
+            raise ValueError("path is needed to run heuristic " + self.get_name())
+
+        if Path(path).joinpath(Path("package", "npm-shrinkwrap.json")).is_file():
+            return True, "A npm-shrinkwrap.json file was found in the package."
+        else:
+            return False, None

--- a/guarddog/analyzer/metadata/npm/npm_shrinkwrap_file.py
+++ b/guarddog/analyzer/metadata/npm/npm_shrinkwrap_file.py
@@ -3,20 +3,22 @@ from pathlib import Path
 
 from guarddog.analyzer.metadata.detector import Detector
 
+
 class NPMShrinkwrapFile(Detector):
     def __init__(self):
         super().__init__(
             name="npm_shrinkwrap_file",
-            description="Identify packages with a npm-shrinkwrap.json file which prevents end users from updating transitive dependencies."
+            description="Identify packages with a npm-shrinkwrap.json file \
+which prevents end users from updating transitive dependencies.",
         )
 
     def detect(
-            self,
-            package_info,
-            path: Optional[str] = None,
-            name: Optional[str] = None,
-            version: Optional[str] = None,
-            ) -> tuple[bool, Optional[str]]:
+        self,
+        package_info,
+        path: Optional[str] = None,
+        name: Optional[str] = None,
+        version: Optional[str] = None,
+    ) -> tuple[bool, Optional[str]]:
         if path is None:
             raise ValueError("path is needed to run heuristic " + self.get_name())
 

--- a/tests/analyzer/metadata/test_npm_shrinkwrap_file.py
+++ b/tests/analyzer/metadata/test_npm_shrinkwrap_file.py
@@ -1,0 +1,15 @@
+from copy import deepcopy
+
+from guarddog.analyzer.metadata.npm.npm_shrinkwrap_file import (
+    NPMShrinkwrapFile,
+)
+
+from tests.analyzer.metadata.resources.package_fixtures import npm_package_info
+
+class TestNPMShrinkwrapFile:
+    detector = NPMShrinkwrapFile()
+
+    def test_npm_shrinkwrap_check(self, mocker):
+        mocker.patch("pathlib.Path.is_file", lambda self: True)
+        result, desc = self.detector.detect(deepcopy(npm_package_info), path="./")
+        assert result


### PR DESCRIPTION
This PR adds a new check for NPM packages.

It's possible to publish a package on NPM with a [`npm-shrinkwrap.json`](https://docs.npmjs.com/cli/v8/configuring-npm/npm-shrinkwrap-json) file which locks transitive dependencies, preventing users to use their own. This is not recommended by NPM:

> The recommended use-case for npm-shrinkwrap.json is applications deployed through the publishing process on the registry: for example, daemons and command-line tools intended as global installs or devDependencies. It's strongly discouraged for library authors to publish this file, since that would prevent end users from having control over transitive dependency updates.