### PR TITLE
Update the shady-links rule to match IPs

### DIFF
--- a/guarddog/analyzer/sourcecode/shady-links.yml
+++ b/guarddog/analyzer/sourcecode/shady-links.yml
@@ -13,7 +13,7 @@ rules:
           - pattern-regex: (http[s]?:\/\/.*\.(link|xyz|tk|ml|ga|cf|gq|pw|top|club|mw|bd|ke|am|sbs|date|quest|cd|bid|cd|ws|icu|cam|uno|email|stream))$
           - pattern-regex: (http[s]?:\/\/.*\.(link|xyz|tk|ml|ga|cf|gq|pw|top|club|mw|bd|ke|am|sbs|date|quest|cd|bid|cd|ws|icu|cam|uno|email|stream)\/)
           - pattern-regex: (http[s]?:\/\/[^/?#]*(?:\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}))
-          - pattern-regex: (http[s]?://[^\[/?#]*(?:\[(?:([A-Fa-f0-9]{1,4}:){0,7}|:):?[A-Fa-f0-9]{1,4}\]))
+          - pattern-regex: (http[s]?://[^\[/?#]*(?:\[(([A-Fa-f0-9]{1,4}:){0,7}|:):?[A-Fa-f0-9]{1,4}(:[A-Fa-f0-9]{1,4}){0,7})\])
     languages:
       - python
       - javascript

--- a/guarddog/analyzer/sourcecode/shady-links.yml
+++ b/guarddog/analyzer/sourcecode/shady-links.yml
@@ -12,6 +12,8 @@ rules:
           - pattern-regex: (http[s]?:\/\/bit\.ly.*)$
           - pattern-regex: (http[s]?:\/\/.*\.(link|xyz|tk|ml|ga|cf|gq|pw|top|club|mw|bd|ke|am|sbs|date|quest|cd|bid|cd|ws|icu|cam|uno|email|stream))$
           - pattern-regex: (http[s]?:\/\/.*\.(link|xyz|tk|ml|ga|cf|gq|pw|top|club|mw|bd|ke|am|sbs|date|quest|cd|bid|cd|ws|icu|cam|uno|email|stream)\/)
+          - pattern-regex: (http[s]?:\/\/[^/?#]*(?:\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}))
+          - pattern-regex: (http[s]?://[^\[/?#]?(?:\[([A-Fa-f0-9]{1,4}:){0,7}:?[A-Fa-f0-9]{1,4}\]))
     languages:
       - python
       - javascript

--- a/guarddog/analyzer/sourcecode/shady-links.yml
+++ b/guarddog/analyzer/sourcecode/shady-links.yml
@@ -13,7 +13,7 @@ rules:
           - pattern-regex: (http[s]?:\/\/.*\.(link|xyz|tk|ml|ga|cf|gq|pw|top|club|mw|bd|ke|am|sbs|date|quest|cd|bid|cd|ws|icu|cam|uno|email|stream))$
           - pattern-regex: (http[s]?:\/\/.*\.(link|xyz|tk|ml|ga|cf|gq|pw|top|club|mw|bd|ke|am|sbs|date|quest|cd|bid|cd|ws|icu|cam|uno|email|stream)\/)
           - pattern-regex: (http[s]?:\/\/[^/?#]*(?:\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}))
-          - pattern-regex: (http[s]?://[^\[/?#]?(?:\[([A-Fa-f0-9]{1,4}:){0,7}:?[A-Fa-f0-9]{1,4}\]))
+          - pattern-regex: (http[s]?://[^\[/?#]*(?:\[(?:([A-Fa-f0-9]{1,4}:){0,7}|:):?[A-Fa-f0-9]{1,4}\]))
     languages:
       - python
       - javascript

--- a/tests/analyzer/sourcecode/shady-links.py
+++ b/tests/analyzer/sourcecode/shady-links.py
@@ -64,6 +64,42 @@ os.system(
 # ruleid: shady-links
 req = urllib3.Request("https://grabify.link/E09EIF", headers={"User-Agent": os})
 
+""" RULEID: IPv4
+"""
+
+# ruleid: shady-links
+req = urllib3.Request("https://root@127.0.0.1", headers={"User-Agent": os})
+
+# ruleid: shady-links
+req = urllib3.Request("https://root@127.0.0.1:42", headers={"User-Agent": os})
+
+# ruleid: shady-links
+req = urllib3.Request("https://root@127.0.0.1", headers={"User-Agent": os})
+
+# ruleid: shady-links
+req = urllib3.Request("https://root:pw@127.0.0.1", headers={"User-Agent": os})
+
+""" RULEID: IPv6
+"""
+
+# ruleid: shady-links
+req = urllib3.Request("https://[::1]", headers={"User-Agent": os})
+
+# ruleid: shady-links
+req = urllib3.Request("https://[::1]:42", headers={"User-Agent": os})
+
+# ruleid: shady-links
+req = urllib3.Request("https://[12aB::1]", headers={"User-Agent": os})
+
+# ruleid: shady-links
+req = urllib3.Request("https://[12ab:12AB:12ab:12BA:12ab:12Ab:12aB:12Ab]", headers={"User-Agent": os})
+
+# ruleid: shady-links
+req = urllib3.Request("https://root@[::1]", headers={"User-Agent": os})
+
+# ruleid: shady-links
+req = urllib3.Request("https://root:pw@[::1]", headers={"User-Agent": os})
+
 # todoruleid: shady-links
 request(
     # todoruleid: shady-links

--- a/tests/analyzer/sourcecode/shady-links.py
+++ b/tests/analyzer/sourcecode/shady-links.py
@@ -68,6 +68,9 @@ req = urllib3.Request("https://grabify.link/E09EIF", headers={"User-Agent": os})
 """
 
 # ruleid: shady-links
+req = urllib3.Request("https://127.0.0.1/foo.exe", headers={"User-Agent": os})
+
+# ruleid: shady-links
 req = urllib3.Request("https://root@127.0.0.1", headers={"User-Agent": os})
 
 # ruleid: shady-links
@@ -83,7 +86,7 @@ req = urllib3.Request("https://root:pw@127.0.0.1", headers={"User-Agent": os})
 """
 
 # ruleid: shady-links
-req = urllib3.Request("https://[::1]", headers={"User-Agent": os})
+req = urllib3.Request("https://[::1]/foo.exe", headers={"User-Agent": os})
 
 # ruleid: shady-links
 req = urllib3.Request("https://[::1]:42", headers={"User-Agent": os})

--- a/tests/analyzer/sourcecode/shady-links.py
+++ b/tests/analyzer/sourcecode/shady-links.py
@@ -71,13 +71,13 @@ req = urllib3.Request("https://grabify.link/E09EIF", headers={"User-Agent": os})
 req = urllib3.Request("https://127.0.0.1/foo.exe", headers={"User-Agent": os})
 
 # ruleid: shady-links
-req = urllib3.Request("https://root@127.0.0.1", headers={"User-Agent": os})
+req = urllib3.Request("https://root@1.2.3.4", headers={"User-Agent": os})
 
 # ruleid: shady-links
-req = urllib3.Request("https://root@127.0.0.1:42", headers={"User-Agent": os})
+req = urllib3.Request("https://root@12.34.56.78:42", headers={"User-Agent": os})
 
 # ruleid: shady-links
-req = urllib3.Request("https://root@127.0.0.1", headers={"User-Agent": os})
+req = urllib3.Request("https://root@123.234.156.178", headers={"User-Agent": os})
 
 # ruleid: shady-links
 req = urllib3.Request("https://root:pw@127.0.0.1", headers={"User-Agent": os})
@@ -89,7 +89,7 @@ req = urllib3.Request("https://root:pw@127.0.0.1", headers={"User-Agent": os})
 req = urllib3.Request("https://[::1]/foo.exe", headers={"User-Agent": os})
 
 # ruleid: shady-links
-req = urllib3.Request("https://[::1]:42", headers={"User-Agent": os})
+req = urllib3.Request("https://[::abcd:1]:42", headers={"User-Agent": os})
 
 # ruleid: shady-links
 req = urllib3.Request("https://[12aB::1]", headers={"User-Agent": os})
@@ -98,7 +98,7 @@ req = urllib3.Request("https://[12aB::1]", headers={"User-Agent": os})
 req = urllib3.Request("https://[12ab:12AB:12ab:12BA:12ab:12Ab:12aB:12Ab]", headers={"User-Agent": os})
 
 # ruleid: shady-links
-req = urllib3.Request("https://root@[::1]", headers={"User-Agent": os})
+req = urllib3.Request("https://root@[1234:AbCd:1234::fedc:1]", headers={"User-Agent": os})
 
 # ruleid: shady-links
 req = urllib3.Request("https://root:pw@[::1]", headers={"User-Agent": os})


### PR DESCRIPTION
The `shady-links` rule try to match suspicious URLs. However, it's not looking for IPs although those are more discrete means to reach C2 instances. This PR add support to detect IPv4 & IPv6