### PR TITLE
[Bugfix] NPM Package Info Writing

### DIFF
--- a/guarddog/scanners/scanner.py
+++ b/guarddog/scanners/scanner.py
@@ -259,7 +259,9 @@ class PackageScanner(Scanner):
 
         results = self.analyzer.analyze(file_path, package_info, rules, name, version)
         if write_package_info:
-            suffix = f"{name}-{version}" if version is not None else name
+            package_name = name.replace("/", "-")
+            suffix = f"{package_name}-{version}" if version is not None else package_name
+            
             with open(os.path.join(results["path"], f'package_info-{suffix}.json'), "w") as file:
                 file.write(json.dumps(package_info))
 

--- a/guarddog/scanners/scanner.py
+++ b/guarddog/scanners/scanner.py
@@ -261,7 +261,6 @@ class PackageScanner(Scanner):
         if write_package_info:
             package_name = name.replace("/", "-")
             suffix = f"{package_name}-{version}" if version is not None else package_name
-            
             with open(os.path.join(results["path"], f'package_info-{suffix}.json'), "w") as file:
                 file.write(json.dumps(package_info))
 


### PR DESCRIPTION
Fixes error found when scanning NPM packages in guarddog-cron: https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fguarddog-cron-dev-guarddog-scan/log-events/2024$252F04$252F02$252F$255B$2524LATEST$255D6c466d58e17c4baba3fc4037e8add1dc

If we scan an NPM package with a slash in its name (ex. `@sroussey/usearch`), Guarddog fails to write the package metadata since it tries to create a file in a dir that doesn't exist. This fixes that bug.

```
LAMBDA_WARNING: Unhandled exception. The most likely cause is an issue in the function code. However, in rare cases, a Lambda runtime update can cause unexpected function behavior. For functions using managed runtimes, runtime updates can be triggered by a function change, or can be applied automatically. To determine if the runtime has been updated, check the runtime version in the INIT_START log entry. If this error correlates with a change in the runtime version, you may be able to mitigate this error by temporarily rolling back to the previous runtime version. For more information, see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-update.html
[ERROR] FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmpzyim_gna/@sroussey-usearch/package_info-@sroussey/usearch-2.10.4.json'
Traceback (most recent call last):
  File "/function/handler.py", line 198, in run
    process_sqs_event(records)
  File "/function/handler.py", line 187, in process_sqs_event
    do_scan_package(package, version, ecosystem)
  File "/function/handler.py", line 114, in do_scan_package
    results = scanner.scan_remote(
  File "/function/guarddog/scanners/scanner.py", line 289, in scan_remote
    return self._scan_remote(name, base_dir, version, rules, write_package_info)
  File "/function/guarddog/scanners/scanner.py", line 263, in _scan_remote
    with open(os.path.join(results["path"], f'package_info-{suffix}.json'), "w") as file:
```

