### PR TITLE
[SINT-1985] Decrease "npm_metadata_mismatch" noisiness

### DIFF
--- a/guarddog/analyzer/metadata/npm/npm_metadata_mismatch.py
+++ b/guarddog/analyzer/metadata/npm/npm_metadata_mismatch.py
@@ -7,13 +7,7 @@ from guarddog.analyzer.metadata.detector import Detector
 # List of fields where mismatch between package.json and NPM can carry malicious information
 # (field, expected type)
 MANIFEST_FIELDS_CHECKLIST = {
-    "dependencies": dict,
-    "devDependencies": dict,
     "scripts": dict,
-    "main": str,
-    "repository": dict,
-    "bugs": dict,
-    "homepage": str
 }
 
 
@@ -21,7 +15,7 @@ class NPMMetadataMismatch(Detector):
     def __init__(self):
         super().__init__(
             name="npm_metadata_mismatch",
-            description="Identify packages which have mismatches between the npm pacakge manifest and the package info"
+            description="Identify packages which have mismatches between the npm package manifest and the package info for some critical fields"
         )
 
     def detect(self, package_info, path: Optional[str] = None, name: Optional[str] = None,
@@ -43,7 +37,7 @@ class NPMMetadataMismatch(Detector):
             field: difference_at_key(version_info, package_manifest, field, field_type)
             for field, field_type in MANIFEST_FIELDS_CHECKLIST.items()
         }
-        number_different = sum(len(v) for k, v in diff.items())
+        number_different = sum(len(v) for v in diff.values())
         diff_description = describe_diff(diff) if number_different != 0 else "No differences found"
         return number_different != 0, diff_description
 
@@ -61,7 +55,7 @@ def diff_at_key_dict(version_at_key: dict[str, Optional[str]], manifest_at_key: 
     ]
 
 
-def difference_at_key(version_info: dict[str, Any], package_manifest: dict[str, Any], key: str, key_type) -> Diff:
+def difference_at_key(version_info: dict[str, Any], package_manifest: dict[str, Any], key: str, key_type: type) -> Diff:
     version_at_key = version_info.get(key, key_type())
     manifest_at_key = package_manifest.get(key, key_type())
     if not (isinstance(version_at_key, key_type) and isinstance(manifest_at_key, key_type)):

--- a/tests/analyzer/metadata/test_npm_metadata_mismatch.py
+++ b/tests/analyzer/metadata/test_npm_metadata_mismatch.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-import json
 
 import pytest
 
@@ -35,8 +34,11 @@ class TestNPMMetadataMismatch:
         (None, None, None, False),
         (["scripts", "preinstall"], "this-is-the-same.sh", "this-is-the-same.sh", False),
         (["scripts", "preinstall"], None, "this-is-not-the-same.sh", True),
-        (["dependencies", "does.not.exit"], None, "1.0.1", True),
-        (["dependencies", "does.not.exit"], "1.1.0", "1.0.1", True),
+        (["scripts", "preinstall"], "this-is-not-the-same.sh", None, True),
+        (["scripts", "preinstall"], "this-is-not-the-same.sh", "another-script.js", True),
+        # Other fields than "scripts" are ignored to decrease false positives.
+        (["dependencies", "does.not.exit"], None, "1.0.1", False),
+        (["dependencies", "does.not.exit"], "1.1.0", "1.0.1", False),
     ]
 
     @pytest.mark.parametrize("modification", test_data)
@@ -50,8 +52,7 @@ class TestNPMMetadataMismatch:
         mocker.patch("json.loads", lambda v: package_json_metadata)
         mocker.patch("pathlib.Path.read_text", lambda self: None)
 
-        result, desc = self.mismatch_detector.detect(npm_version_metadata, path="./")
-        print(desc)
+        result, _ = self.mismatch_detector.detect(npm_version_metadata, path="./")
         assert result == modification[3]
         result, _ = self.mismatch_detector.detect(npm_version_metadata, path="./", version="2.1.0")
         assert result == modification[3]


### PR DESCRIPTION
## What does this PR do?
This PR changes this metadata heuristic to only check the `scripts` field in `package.json`. It addresses https://github.com/DataDog/guarddog/issues/330.

## Motivation
We run guarddog on many NPM packages and this rule triggers a lot. Take the `axios v0.21.4` package for instance. The heuristic triggers because the `repository` field has value `git+https://github.com/axios/axios.git` on NPM and `https://github.com/axios/axios.git` in `package.json`. We get more than 7000 such findings daily which reduces the interest of the rule as high risk signals are less visible. We believe checking only the `scripts` fields should still catch NPM manifest confusion attacks (as described in https://jfrog.com/blog/addressing-the-npm-manifest-confusion-vulnerability).
