### PR TITLE
Pass expected dictionary format for status code verification

### DIFF
--- a/guarddog/cli.py
+++ b/guarddog/cli.py
@@ -156,7 +156,7 @@ def _verify(path, rules, exclude_rules, output_format, exit_non_zero_on_finding,
         print(return_value)
      
     if exit_non_zero_on_finding:
-        exit_with_status_code([ result['result'] for result in results ])
+        exit_with_status_code([result['result'] for result in results])
 
     return return_value  # this is mostly for testing
 

--- a/guarddog/cli.py
+++ b/guarddog/cli.py
@@ -154,7 +154,7 @@ def _verify(path, rules, exclude_rules, output_format, exit_non_zero_on_finding,
 
     if output_format is not None:
         print(return_value)
-     
+
     if exit_non_zero_on_finding:
         exit_with_status_code([result['result'] for result in results])
 

--- a/guarddog/cli.py
+++ b/guarddog/cli.py
@@ -154,9 +154,9 @@ def _verify(path, rules, exclude_rules, output_format, exit_non_zero_on_finding,
 
     if output_format is not None:
         print(return_value)
-
+     
     if exit_non_zero_on_finding:
-        exit_with_status_code(results)
+        exit_with_status_code([ result['result'] for result in results ])
 
     return return_value  # this is mostly for testing
 


### PR DESCRIPTION
### Problem:
`guarddog  pypi verify --exit-non-zero-on-finding requiremets.txt` always returns 0 code. 

Dictionary format which is passed for verification: 
`[{"dependency": "", "version": "", "result": {"issues": 0, "errors": {}, "results": {}, "path": ""}}]`

`exit_with_status_code` function doesn't expect "issues" to be in the nested dictionary: 
```
    for result in results:
        num_issues = result.get('issues', 0)
```
