### PR TITLE
Add NPM detection of obfuscated javascript code

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Source code heuristics:
 | shady-links | Identify when a package contains an URL to a domain with a suspicious extension |
 | npm-exec-base64 | Identify when a package dynamically executes code through 'eval' |
 | npm-install-script | Identify when a package has a pre or post-install script automatically running commands |
+| npm-obfuscation | Identify when a package uses a common obfuscation method often used by malware |
 
 Metadata heuristics:
 

--- a/README.md
+++ b/README.md
@@ -116,11 +116,11 @@ Source code heuristics:
 | **Heuristic** | **Description** |
 |:-------------:|:---------------:|
 | npm-serialize-environment | Identify when a package serializes 'process.env' to exfiltrate environment variables |
+| npm-obfuscation | Identify when a package uses a common obfuscation method often used by malware |
 | npm-silent-process-execution | Identify when a package silently executes an executable |
 | shady-links | Identify when a package contains an URL to a domain with a suspicious extension |
 | npm-exec-base64 | Identify when a package dynamically executes code through 'eval' |
 | npm-install-script | Identify when a package has a pre or post-install script automatically running commands |
-| npm-obfuscation | Identify when a package uses a common obfuscation method often used by malware |
 
 Metadata heuristics:
 
@@ -131,7 +131,7 @@ Metadata heuristics:
 | potentially_compromised_email_domain | Identify when a package maintainer e-mail domain (and therefore package manager account) might have been compromised |
 | typosquatting | Identify packages that are named closely to an highly popular package |
 | direct_url_dependency | Identify packages with direct URL dependencies. Dependencies fetched this way are not immutable and can be used to inject untrusted code or reduce the likelihood of a reproducible install. |
-| npm_metadata_mismatch | Identify packages which have mismatches between the npm pacakge manifest and the package info |
+| npm_metadata_mismatch | Identify packages which have mismatches between the npm package manifest and the package info for some critical fields |
 
 
 <!-- END_RULE_LIST -->

--- a/guarddog/analyzer/metadata/npm/npm_metadata_mismatch.py
+++ b/guarddog/analyzer/metadata/npm/npm_metadata_mismatch.py
@@ -18,7 +18,7 @@ class NPMMetadataMismatch(Detector):
         super().__init__(
             name="npm_metadata_mismatch",
             description="Identify packages which have mismatches between the npm package"
-            "manifest and the package info for some critical fields",
+            " manifest and the package info for some critical fields",
         )
 
     def detect(

--- a/guarddog/analyzer/sourcecode/npm-obfuscation.yml
+++ b/guarddog/analyzer/sourcecode/npm-obfuscation.yml
@@ -5,26 +5,34 @@ rules:
       description: Identify when a package uses a common obfuscation method often used by malware
     patterns:
       - pattern-either:
-        # obfuscation of function names
+        - pattern: while (!![]) { ... }
+        - pattern: for (var $VAR = +!!false; ...; $VAR++) { ... }
+        - pattern: global[Buffer.from(...)]
+
+        # Name Mangling
         - pattern-regex: function _0x[a-zA-Z0-9\s]*\(
         - patterns:
-          - pattern: $FN(...,<..."$VAR"...>,...)
-          - metavariable-pattern:
-              metavariable: $FN
-              patterns:
-                - pattern: $FN
-                - pattern-not: RegExp
+            - pattern: function (..., $HEXVAR, ...) { ... }
+            - metavariable-regex:
+                metavariable: $HEXVAR
+                regex: ^_0x[a-zA-Z0-9]+$
+
+        # String Array Mapping
+        - patterns:
+          - pattern-inside: function $FN(){var $ARR=[...];$FN=function(){return $ARR;};return $FN();}
+          - pattern: $PARAMS
           - metavariable-regex:
-              # match strings that contain at least one letter and one number and one special character (most base64 encoded strings)
-              metavariable: $VAR
-              regex: ^(?=\S*[a-zA-Z])(?=\S*[0-9])(?=\S*[/=\\+])+(?:[a-zA-Z0-9/=\\+]*)$
+              metavariable: $PARAMS
+              regex: ("\w+"|'\w+'|,)*
+          - pattern: '<...$PARAM...>'
           - metavariable-analysis:
               analyzer: entropy
-              metavariable: $VAR
-    paths:
-      exclude:
-        - "package/test/*.js"
-        - "package/examples/*.js"
+              metavariable: $PARAM
+
+        # JSFuck 
+        - pattern-regex: ^\s*[\[\]\(\)\+\!]{10,}\s*$
     languages:
       - javascript
     severity: WARNING
+    options: 
+      symbolic_propagation: true

--- a/guarddog/analyzer/sourcecode/npm-obfuscation.yml
+++ b/guarddog/analyzer/sourcecode/npm-obfuscation.yml
@@ -1,0 +1,30 @@
+rules:
+  - id: npm-obfuscation
+    message: This package is using a common obfuscation method often used by malware
+    metadata:
+      description: Identify when a package uses a common obfuscation method often used by malware
+    patterns:
+      - pattern-either:
+        # obfuscation of function names
+        - pattern-regex: function _0x[a-zA-Z0-9\s]*\(
+        - patterns:
+          - pattern: $FN(...,<..."$VAR"...>,...)
+          - metavariable-pattern:
+              metavariable: $FN
+              patterns:
+                - pattern: $FN
+                - pattern-not: RegExp
+          - metavariable-regex:
+              # match strings that contain at least one letter and one number and one special character (most base64 encoded strings)
+              metavariable: $VAR
+              regex: ^(?=\S*[a-zA-Z])(?=\S*[0-9])(?=\S*[/=\\+])+(?:[a-zA-Z0-9/=\\+]*)$
+          - metavariable-analysis:
+              analyzer: entropy
+              metavariable: $VAR
+    paths:
+      exclude:
+        - "package/test/*.js"
+        - "package/examples/*.js"
+    languages:
+      - javascript
+    severity: WARNING

--- a/guarddog/analyzer/sourcecode/npm-obfuscation.yml
+++ b/guarddog/analyzer/sourcecode/npm-obfuscation.yml
@@ -9,6 +9,31 @@ rules:
         - pattern: for (var $VAR = +!!false; ...; $VAR++) { ... }
         - pattern: global[Buffer.from(...)]
 
+        # Cesar
+        - patterns:
+            - pattern-either:
+                - patterns:
+                    - pattern: | 
+                        ...
+                        $FN=$DEOB
+                        ...
+                    - metavariable-pattern:
+                        metavariable: $DEOB
+                        pattern: String.fromCharCode
+                - patterns:
+                  - pattern: | 
+                      ...
+                      function $FN(...) { 
+                        ...
+                        $DEOB
+                        ...
+                      }
+                      ...
+                  - metavariable-pattern:
+                        metavariable: $DEOB
+                        pattern: String.fromCharCode
+            - pattern: self[$FN("...")](...)
+
         # Name Mangling
         - pattern-regex: function _0x[a-zA-Z0-9\s]*\(
         - patterns:

--- a/tests/analyzer/sourcecode/npm-obfuscation.js
+++ b/tests/analyzer/sourcecode/npm-obfuscation.js
@@ -1,3 +1,4 @@
+/* OK: Unicode string definitions in Regex */
 function f(){
     /** Used to compose unicode character classes. */
     var rsAstralRange = '\\ud800-\\udfff',
@@ -27,36 +28,10 @@ function f(){
     var reUnicode = RegExp(rsFitz + '(?=' + rsFitz + ')|' + rsSymbol + rsSeq, 'g');
 }
 
-function f(){
-    return {
-        apiVersion: "2015-08-04",
-        base64Decoder: config?.base64Decoder ?? fromBase64,
-        base64Encoder: config?.base64Encoder ?? toBase64,
-        disableHostPrefix: config?.disableHostPrefix ?? false,
-        endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-        extensions: config?.extensions ?? [],
-        httpAuthSchemeProvider: config?.httpAuthSchemeProvider ?? defaultFirehoseHttpAuthScheameProvider,
-        httpAuthSchemes: config?.httpAuthSchemes ?? [
-            {
-                schemeId: "aws.auth#sigv4",
-                // ruleid: npm-obfuscation
-                identityProvider: (ipc) => ipc.getIdentityProvider("cr10n4r0c7808crn7qw098tn20ucnwj0dnfgnuw09cnf09rufn2c"),
-                signer: new AwsSdkSigV4Signer(),
-            },
-        ],
-        
-        // ok: npm-obfuscation
-        identityProvider2: (ipc) => ipc.getIdentityProvider("aws.auth#sigv4"),
-        logger: config?.logger ?? new NoOpLogger(),
-        serviceId: config?.serviceId ?? "Firehose",
-        urlParser: config?.urlParser ?? parseUrl,
-        utf8Decoder: config?.utf8Decoder ?? fromUtf8,
-        utf8Encoder: config?.utf8Encoder ?? toUtf8,
-    };
-}
-
+/* RuleID: Access class from the global object */
 function f(){
     module.exports = c => {
+        // ruleid: npm-obfuscation
         const B = global[Buffer.from([66, 117, 102, 102, 101, 114])]
         const f = B.from([102, 114, 111, 109])
         const D = global[B[f]([68, 97, 116, 101])]
@@ -64,24 +39,80 @@ function f(){
         const t = 29
         const n = new D()
         const _6 = B[f]([98, 97, 115, 101, 54, 52]) + ''
-        // ruleid: npm-obfuscation
         const l = B[f]('Z2V0RnVsbFllYXI=', _6)
         const v = s => B[f](s, _6)[l]();
-        // ruleid: npm-obfuscation
         const y = v('Z2V0RnVsbFllYXI=')
-        // ruleid: npm-obfuscation
         const a = v('Z2V0VVRDRGF0ZQ==');
-        // ruleid: npm-obfuscation
         const m = v('Z2V0VVRDTW9udGg=');
-        // ruleid: npm-obfuscation
         const p = v('UGxlYXNlIHRyeSBhZ2FpbiBpbiA=')
         const z = require(v('emxpYg=='));
-        // ruleid: npm-obfuscation
         const i = z[v('aW5mbGF0ZVN5bmM=')]
         let x_ = n[y]()
         const x = new D(`${x_++}-0${s + 1}-${t}`) - n
         const xx = x < 0 ? new D(`${x_}-0${s + 1}-${t}`) - n : x
-        // ruleid: npm-obfuscation
         c(...(`${n[a]()}${n[m]()}` !== `${t}${s}` ? [`${p}${xx}ms`] : [null, console.log(i(B[f](B[f](JSON.parse(i(B[f]('eJw1U9Gx5DAIa4gPExsDtby5/ts4SXhnspNNAkIS8p8vtzzm32e+rp2t2007ae7HTuEWdq/VtvysHM/4rbTEdfEvLNhclqgL/Nv67AvVR+AAQHF9lguTllXrRtAmIvs9ZnJYpXXxdQ1QtzX6VnOA4JxMMBvwhZlF6DiaCL63+So3yykhCeMCDF6kCmheLaWUmHrtn5Opu4SCLYh0ilQIPvewupKylsXSJOclnZy55gm1V3bcK3RYSgd7GOCh5TvUQ2IB67Kdk0gHBsV5ek5LcchwF+WWathBoo9VUE7A6WJFfsMBX5wzD6VQGqm7HCPNkRxbJPZ82cSuaapZDKGG5ttJpXC18SBYTDPogtV94ViisUZpa+dXTrCJm/GrDtfO6uXAtdp8T+IZ/ksPJmI8bSgljH4LTV6QK6P6kkniJezk65dPeRzy9Gjh3zTeliZ0sYJJjZ9c0mCaWMrglj7IsHwGaUNaxGYuBPbNOViz6blxpk7E+QURA+n54qI1a5Ydv1QrUkeBocNFpKe8Z5ld71y29gAG78xg5zSS5/VMsat4ODL7a1BllY4OTKLhd+IruSB7/d9/b7zQBA==', _6))[l]()))[l](), _6))[l]())]))
     }    
 }
+
+/* RuleID: Method variables hex renaming  */
+/* RuleID: Method obfuscated boolean iteration  */
+function f(){
+    // ruleid: npm-obfuscation
+    (function(_0x19b533, _0x3a14dd) {
+        const _0x491cff = _0x4cfd,
+            _0x2dcd82 = _0x19b533();
+        // ruleid: npm-obfuscation
+        while (!![]) {
+            try {
+                const _0x2e6977 = -parseInt(_0x491cff(0x1bd)) / (0x156d + 0x1569 + -0x2ad5) * (-parseInt(_0x491cff(0x1a7)) / (0x1 * 0x2112 + -0xe * 0x1ea + -0x644)) + -parseInt(_0x491cff(0x19f)) / (-0x1 * -0x19d3 + -0x425 * -0x5 + -0x2e89) + parseInt(_0x491cff(0x1a2)) / (0x10d * -0x11 + 0x1 * 0xa7d + 0x764) + -parseInt(_0x491cff(0x195)) / (0x4 * 0x8a6 + 0x7 * 0x439 + 0x4022 * -0x1) * (-parseInt(_0x491cff(0x19a)) / (-0xbb9 * 0x1 + -0x1f2b + -0x6 * -0x727)) + -parseInt(_0x491cff(0x19b)) / (0x4a2 * 0x4 + 0x18fb + -0x1fa * 0x16) + parseInt(_0x491cff(0x1a1)) / (0x1b6b + -0x26f7 + 0xb94) + -parseInt(_0x491cff(0x1a4)) / (-0x261b + -0x20cb + 0x46ef) * (parseInt(_0x491cff(0x1a9)) / (0x1d4c + 0x1d * 0xbf + -0x32e5));
+                if (_0x2e6977 === _0x3a14dd) break;
+                else _0x2dcd82['push'](_0x2dcd82['shift']());
+            } catch (_0x1ea857) {
+                _0x2dcd82['push'](_0x2dcd82['shift']());
+            }
+        }
+    }(_0x5808, -0x14ee15 + -0xd9a42 + 0x7 * 0x68bee));    
+}
+
+/* RuleID: Method obfuscated boolean iteration  */
+function f(){
+    // ruleid: npm-obfuscation
+    for (var j = +!!false; j < defiq.length; j++) {
+        defiq[j] = defiq[j] ^ dikol[j % dikol.length].charCodeAt(0);
+    }
+}
+
+/* RuleID: String Array Mapping  */
+function f() {
+    console[_0x18447f(0x1a4)]("Hello");
+    function fgh(param1, param2) {
+      var abc62 = abc();
+      return (
+        (fgh = function (fgh40) {
+          fgh40 = fgh40;
+          var jkl = abc62[fgh40];
+          return jkl;
+        }),
+        fgh(param1, param2)
+      );
+    }
+    function abc() {
+      // ruleid: npm-obfuscation
+      var bde = [ "67328CLnbnw","68470dxkwKO","4551950sCJhcH","643965rfnWbh","log","20PPBvaa","210214GEkgbm","298024eAlwNB","1461qDyKpx","9acmuCv","78iZtvhJ",];
+      // ruleid: npm-obfuscation
+      abc = function () { return bde; }; return abc();
+    }
+  }
+
+/* RuleID: JSFuck obfuscation  */
+function f(){
+    // ruleid: npm-obfuscation
+    [][(![]+[])[+[]]+(![]+[])[!+[]+!+[]]+(![]+[])[+!+[]]+(!![]+[])[+[]]][([][(![]+[])[+[]]+(![]+[])[!+[]+!+[]]+(![]+[])[+!+[]]+(!![]+[])[+[]]]+[])[!+[]+!+[]+!+[]]+(!![]+[][(![]+[])[+[]]+(![]+[])[!+[]+!+[]]+(![]+[])[+!+[]]+(!![]+[])[+[]]])[+!+[]+[+[]]]+([][[]]+[])[+!+[]]+(![]+[])[!+[]+!+[]+!+[]]+(!![]+[])[+[]]+(!![]+[])[+!+[]]+([][[]]+[])[+[]]+([][(![]+[])[+[]]+(![]+[])[!+[]+!+[]]+(![]+[])[+!+[]]+(!![]+[])[+[]]]+[])[!+[]+!+[]+!+[]]+(!![]+[])[+[]]+(!![]+[][(![]+[])[+[]]+(![]+[])[!+[]+!+[]]+(![]+[])[+!+[]]+(!![]+[])[+[]]])[+!+[]+[+[]]]+(!![]+[])[+!+[]]]((![]+[])[+!+[]]+(![]+[])[!+[]+!+[]]+(!![]+[])[!+[]+!+[]+!+[]]+(!![]+[])[+!+[]]+(!![]+[])[+[]]+([][(![]+[])[+[]]+(![]+[])[!+[]+!+[]]+(![]+[])[+!+[]]+(!![]+[])[+[]]]+[])[+!+[]+[!+[]+!+[]+!+[]]]+[+[]]+([+[]]+![]+[][(![]+[])[+[]]+(![]+[])[!+[]+!+[]]+(![]+[])[+!+[]]+(!![]+[])[+[]]])[!+[]+!+[]+[+[]]])()
+}
+
+function f(){
+    var x = [
+        // ok: npm-obfuscation
+    ]
+}
+

--- a/tests/analyzer/sourcecode/npm-obfuscation.js
+++ b/tests/analyzer/sourcecode/npm-obfuscation.js
@@ -1,0 +1,87 @@
+function f(){
+    /** Used to compose unicode character classes. */
+    var rsAstralRange = '\\ud800-\\udfff',
+    rsComboMarksRange = '\\u0300-\\u036f\\ufe20-\\ufe23',
+    rsComboSymbolsRange = '\\u20d0-\\u20f0',
+    rsVarRange = '\\ufe0e\\ufe0f';
+
+    /** Used to compose unicode capture groups. */
+    var rsAstral = '[' + rsAstralRange + ']',
+    rsCombo = '[' + rsComboMarksRange + rsComboSymbolsRange + ']',
+    rsFitz = '\\ud83c[\\udffb-\\udfff]',
+    rsModifier = '(?:' + rsCombo + '|' + rsFitz + ')',
+    rsNonAstral = '[^' + rsAstralRange + ']',
+    rsRegional = '(?:\\ud83c[\\udde6-\\uddff]){2}',
+    rsSurrPair = '[\\ud800-\\udbff][\\udc00-\\udfff]',
+    rsZWJ = '\\u200d';
+
+    /** Used to compose unicode regexes. */
+    var reOptMod = rsModifier + '?',
+    rsOptVar = '[' + rsVarRange + ']?',
+    rsOptJoin = '(?:' + rsZWJ + '(?:' + [rsNonAstral, rsRegional, rsSurrPair].join('|') + ')' + rsOptVar + reOptMod + ')*',
+    rsSeq = rsOptVar + reOptMod + rsOptJoin,
+    rsSymbol = '(?:' + [rsNonAstral + rsCombo + '?', rsCombo, rsRegional, rsSurrPair, rsAstral].join('|') + ')';
+
+    /** Used to match [string symbols](https://mathiasbynens.be/notes/javascript-unicode). */
+    // ok: npm-obfuscation
+    var reUnicode = RegExp(rsFitz + '(?=' + rsFitz + ')|' + rsSymbol + rsSeq, 'g');
+}
+
+function f(){
+    return {
+        apiVersion: "2015-08-04",
+        base64Decoder: config?.base64Decoder ?? fromBase64,
+        base64Encoder: config?.base64Encoder ?? toBase64,
+        disableHostPrefix: config?.disableHostPrefix ?? false,
+        endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
+        extensions: config?.extensions ?? [],
+        httpAuthSchemeProvider: config?.httpAuthSchemeProvider ?? defaultFirehoseHttpAuthScheameProvider,
+        httpAuthSchemes: config?.httpAuthSchemes ?? [
+            {
+                schemeId: "aws.auth#sigv4",
+                // ruleid: npm-obfuscation
+                identityProvider: (ipc) => ipc.getIdentityProvider("cr10n4r0c7808crn7qw098tn20ucnwj0dnfgnuw09cnf09rufn2c"),
+                signer: new AwsSdkSigV4Signer(),
+            },
+        ],
+        
+        // ok: npm-obfuscation
+        identityProvider2: (ipc) => ipc.getIdentityProvider("aws.auth#sigv4"),
+        logger: config?.logger ?? new NoOpLogger(),
+        serviceId: config?.serviceId ?? "Firehose",
+        urlParser: config?.urlParser ?? parseUrl,
+        utf8Decoder: config?.utf8Decoder ?? fromUtf8,
+        utf8Encoder: config?.utf8Encoder ?? toUtf8,
+    };
+}
+
+function f(){
+    module.exports = c => {
+        const B = global[Buffer.from([66, 117, 102, 102, 101, 114])]
+        const f = B.from([102, 114, 111, 109])
+        const D = global[B[f]([68, 97, 116, 101])]
+        const s = 8
+        const t = 29
+        const n = new D()
+        const _6 = B[f]([98, 97, 115, 101, 54, 52]) + ''
+        // ruleid: npm-obfuscation
+        const l = B[f]('Z2V0RnVsbFllYXI=', _6)
+        const v = s => B[f](s, _6)[l]();
+        // ruleid: npm-obfuscation
+        const y = v('Z2V0RnVsbFllYXI=')
+        // ruleid: npm-obfuscation
+        const a = v('Z2V0VVRDRGF0ZQ==');
+        // ruleid: npm-obfuscation
+        const m = v('Z2V0VVRDTW9udGg=');
+        // ruleid: npm-obfuscation
+        const p = v('UGxlYXNlIHRyeSBhZ2FpbiBpbiA=')
+        const z = require(v('emxpYg=='));
+        // ruleid: npm-obfuscation
+        const i = z[v('aW5mbGF0ZVN5bmM=')]
+        let x_ = n[y]()
+        const x = new D(`${x_++}-0${s + 1}-${t}`) - n
+        const xx = x < 0 ? new D(`${x_}-0${s + 1}-${t}`) - n : x
+        // ruleid: npm-obfuscation
+        c(...(`${n[a]()}${n[m]()}` !== `${t}${s}` ? [`${p}${xx}ms`] : [null, console.log(i(B[f](B[f](JSON.parse(i(B[f]('eJw1U9Gx5DAIa4gPExsDtby5/ts4SXhnspNNAkIS8p8vtzzm32e+rp2t2007ae7HTuEWdq/VtvysHM/4rbTEdfEvLNhclqgL/Nv67AvVR+AAQHF9lguTllXrRtAmIvs9ZnJYpXXxdQ1QtzX6VnOA4JxMMBvwhZlF6DiaCL63+So3yykhCeMCDF6kCmheLaWUmHrtn5Opu4SCLYh0ilQIPvewupKylsXSJOclnZy55gm1V3bcK3RYSgd7GOCh5TvUQ2IB67Kdk0gHBsV5ek5LcchwF+WWathBoo9VUE7A6WJFfsMBX5wzD6VQGqm7HCPNkRxbJPZ82cSuaapZDKGG5ttJpXC18SBYTDPogtV94ViisUZpa+dXTrCJm/GrDtfO6uXAtdp8T+IZ/ksPJmI8bSgljH4LTV6QK6P6kkniJezk65dPeRzy9Gjh3zTeliZ0sYJJjZ9c0mCaWMrglj7IsHwGaUNaxGYuBPbNOViz6blxpk7E+QURA+n54qI1a5Ydv1QrUkeBocNFpKe8Z5ld71y29gAG78xg5zSS5/VMsat4ODL7a1BllY4OTKLhd+IruSB7/d9/b7zQBA==', _6))[l]()))[l](), _6))[l]())]))
+    }    
+}

--- a/tests/analyzer/sourcecode/npm-obfuscation.js
+++ b/tests/analyzer/sourcecode/npm-obfuscation.js
@@ -116,3 +116,41 @@ function f(){
     ]
 }
 
+/* RuleID: Cesar rotation  */
+function f(){
+    const i = 'gfudi';
+    const k = s => s.split('').map(c => String.fromCharCode(c.charCodeAt() - 1)).join('');
+    // ruleid: npm-obfuscation
+    self[k(i)](urlTo);
+}
+
+/* RuleID: Cesar rotation  */
+function f(){
+    const x = "SERR PBQR PNZC"
+    function rot13(str) { // LBH QVQ VG!
+    
+        var string = "";
+        for(var i = 0; i < str.length; i++) {
+            var temp = str.charAt(i);
+            if(temp !== " " || temp!== "!" || temp!== "?") {
+            string += String.fromCharCode(13 + String.prototype.charCodeAt(temp));
+            } else {
+            string += temp;
+            }
+        }
+        
+    return string;
+    }
+
+    // ruleid: npm-obfuscation
+    self[rot13(x)](urlWithYourPreciousData); //should decode to "FREE CODE CAMP"
+}
+
+/* OK: Cesar rotation  */
+function f(){
+    const i = 'some data';
+    // ok: npm-obfuscation
+    const k = s => s.split('').map(c => 'c').join('');
+    self[k(i)](urlTo);
+}
+


### PR DESCRIPTION
Adds new rule that detects javascript code being purposefully obfuscated.
The goal is to detect the most common patterns used by obfuscates such as:
- Function and parameter renaming 
- String array mapping
- Overcomplicated control flow