### PR TITLE
fix: incorrect results and heuristic set

### DIFF
--- a/guarddog/cli.py
+++ b/guarddog/cli.py
@@ -23,8 +23,10 @@ from guarddog.scanners.scanner import PackageScanner
 ALL_RULES = \
     set(get_metadata_detectors(ECOSYSTEM.NPM).keys()) \
     | set(get_metadata_detectors(ECOSYSTEM.PYPI).keys()) | SEMGREP_RULE_NAMES
-NPM_RULES = set(get_metadata_detectors(ECOSYSTEM.NPM).keys()) | SEMGREP_RULE_NAMES
-PYPI_RULES = set(get_metadata_detectors(ECOSYSTEM.PYPI).keys()) | SEMGREP_RULE_NAMES
+NPM_RULES = set(get_metadata_detectors(ECOSYSTEM.NPM).keys()) | \
+    set([rules["id"] for rules in SOURCECODE_RULES[ECOSYSTEM.NPM]])
+PYPI_RULES = set(get_metadata_detectors(ECOSYSTEM.PYPI).keys()) | \
+    set([rules["id"] for rules in SOURCECODE_RULES[ECOSYSTEM.PYPI]])
 EXIT_CODE_ISSUES_FOUND = 1
 
 AVAILABLE_LOG_LEVELS = {


### PR DESCRIPTION
fix #353 
If the user doesn't specify any rules, GuardDog needs to scan through all heuristics and provide the results with all heuristics.
However, I would recommend to separate the source code heuristics into two folders (npm, pypi).