### PR TITLE
Adding FP case to npm-obfuscation

### DIFF
--- a/guarddog/analyzer/sourcecode/npm-obfuscation.yml
+++ b/guarddog/analyzer/sourcecode/npm-obfuscation.yml
@@ -55,7 +55,9 @@ rules:
               metavariable: $PARAM
 
         # JSFuck 
-        - pattern-regex: ^\s*[\[\]\(\)\+\!]{10,}\s*$
+        - patterns:
+          - pattern-not-inside: "..."
+          - pattern-regex: ^\s*[\[\]\(\)\+\!]{10,}\s*$
     languages:
       - javascript
     severity: WARNING

--- a/tests/analyzer/sourcecode/npm-obfuscation.js
+++ b/tests/analyzer/sourcecode/npm-obfuscation.js
@@ -154,3 +154,18 @@ function f(){
     self[k(i)](urlTo);
 }
 
+function f(){
+    // ok: npm-obfuscation
+    console.warn(`
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    
+    WARNING
+    
+    Version discrepancies between server and "${clientRole}" client:
+    + server: ${serverVersion} | client: ${clientVersion}
+    
+    This might lead to unexpected behavior, you should consider to re-install your
+    dependencies on both your server and clients.
+    
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!`);
+}


### PR DESCRIPTION
The following is detected as JSFuck
```
    console.warn(`
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    
    WARNING
    
    Version discrepancies between server and "${clientRole}" client:
    + server: ${serverVersion} | client: ${clientVersion}
    
    This might lead to unexpected behavior, you should consider to re-install your
    dependencies on both your server and clients.
    
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!`);
}
```

This PR fixes it