### PR TITLE
remove redundant docker layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ LABEL org.opencontainers.image.source="https://github.com/DataDog/guarddog/"
 RUN addgroup --system --gid 1000 guarddog \
     && adduser --system --shell /bin/bash --uid 1000 --ingroup guarddog guarddog
 
-RUN mkdir /app
 WORKDIR /app
 
 


### PR DESCRIPTION
Just a nit, but when using `WORKDIR`  instruction you don't need to create it before. It does it automatically for you. Tested by building new tag and running guarddog commands