### PR TITLE
Feature: honor requirements versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ wheels/
 *.egg-info/
 build/
 .coverage*
-
+.cache
+.semgrep

--- a/guarddog/analyzer/metadata/npm/typosquatting.py
+++ b/guarddog/analyzer/metadata/npm/typosquatting.py
@@ -8,7 +8,6 @@ from guarddog.utils.config import TOP_PACKAGES_CACHE_LOCATION
 import requests
 
 
-
 class NPMTyposquatDetector(TyposquatDetector):
     """Detector for typosquatting attacks. Detects if a package name is a typosquat of one of the top 5000 packages.
     Checks for distance one Levenshtein, one-off character swaps, permutations

--- a/guarddog/analyzer/metadata/npm/typosquatting.py
+++ b/guarddog/analyzer/metadata/npm/typosquatting.py
@@ -4,9 +4,9 @@ from datetime import datetime, timedelta
 from typing import Optional
 
 from guarddog.analyzer.metadata.typosquatting import TyposquatDetector
+from guarddog.utils.config import TOP_PACKAGES_CACHE_LOCATION
 import requests
 
-TOP_PACKAGES_CACHE_LOCATION = os.environ.get("GUARDDOG_TOP_PACKAGES_CACHE_LOCATION")
 
 
 class NPMTyposquatDetector(TyposquatDetector):

--- a/guarddog/analyzer/metadata/pypi/typosquatting.py
+++ b/guarddog/analyzer/metadata/pypi/typosquatting.py
@@ -13,7 +13,7 @@ from guarddog.analyzer.metadata.typosquatting import TyposquatDetector
 log = logging.getLogger("guarddog")
 
 
-TOP_PACKAGES_CACHE_LOCATION = os.environ.get('GUARDDOG_TOP_PACKAGES_CACHE_LOCATION')
+
 
 
 class PypiTyposquatDetector(TyposquatDetector):

--- a/guarddog/analyzer/metadata/pypi/typosquatting.py
+++ b/guarddog/analyzer/metadata/pypi/typosquatting.py
@@ -13,9 +13,6 @@ from guarddog.utils.config import TOP_PACKAGES_CACHE_LOCATION
 log = logging.getLogger("guarddog")
 
 
-
-
-
 class PypiTyposquatDetector(TyposquatDetector):
     """
     Detector for typosquatting attacks. Detects if a package name is a typosquat of one of the top 1000 packages.

--- a/guarddog/analyzer/metadata/pypi/typosquatting.py
+++ b/guarddog/analyzer/metadata/pypi/typosquatting.py
@@ -8,7 +8,7 @@ import requests
 import packaging.utils
 
 from guarddog.analyzer.metadata.typosquatting import TyposquatDetector
-
+from guarddog.utils.config import TOP_PACKAGES_CACHE_LOCATION
 
 log = logging.getLogger("guarddog")
 

--- a/guarddog/scanners/npm_project_scanner.py
+++ b/guarddog/scanners/npm_project_scanner.py
@@ -1,6 +1,6 @@
 import json
 import logging
-
+import os
 import requests
 from semantic_version import NpmSpec, Version  # type:ignore
 
@@ -8,29 +8,8 @@ from guarddog.scanners.npm_package_scanner import NPMPackageScanner
 from guarddog.scanners.scanner import ProjectScanner
 
 log = logging.getLogger("guarddog")
-
-
-def find_all_versions(package_name: str, semver_range: str) -> set[str]:
-    url = f"https://registry.npmjs.org/{package_name}"
-    log.debug(f"Retrieving npm package metadata from {url}")
-    response = requests.get(url)
-    if response.status_code != 200:
-        log.debug(f"No version available, status code {response.status_code}")
-        return set()
-
-    data = response.json()
-    versions = list(data["versions"].keys())
-    log.debug(f"Retrieved versions {', '.join(versions)}")
-    result = set()
-    try:
-        npm_spec = NpmSpec(semver_range)
-    except ValueError:  # not a semver range, let's keep it raw
-        result.add(semver_range)
-        return result
-    for v in versions:
-        if Version(v) in npm_spec:
-            result.add(v)
-    return result
+# This flag spedificies if an analysis of all posible versions is required
+VERIFY_ALL_DEPENDENCIES = os.environ.get("GUARDDOG_VERIFY_ALL_DEPENDENCIES", False)
 
 
 class NPMRequirementsScanner(ProjectScanner):
@@ -45,12 +24,63 @@ class NPMRequirementsScanner(ProjectScanner):
         super().__init__(NPMPackageScanner())
 
     def parse_requirements(self, raw_requirements: str) -> dict:
+        """
+        Parses requirements.txt specification and finds all valid
+        versions of each dependency
+
+        Args:
+            raw_requirements (str): contents of package file
+
+        Returns:
+            dict: mapping of dependencies to valid versions
+
+            ex.
+            {
+                ....
+                <dependency-name>: [0.0.1, 0.0.2, ...],
+                ...
+            }
+        """
         package = json.loads(raw_requirements)
         dependencies = package["dependencies"] if "dependencies" in package else {}
-        dev_dependencies = package["devDependencies"] if "devDependencies" in package else {}
+        dev_dependencies = (
+            package["devDependencies"] if "devDependencies" in package else {}
+        )
+
+        def find_all_versions(package_name: str, semver_range: str) -> set[str]:
+            """
+            This helper function retrieves all versions matching the selector
+            """
+            url = f"https://registry.npmjs.org/{package_name}"
+            log.debug(f"Retrieving npm package metadata from {url}")
+            response = requests.get(url)
+            if response.status_code != 200:
+                log.debug(f"No version available, status code {response.status_code}")
+                return set()
+
+            data = response.json()
+            versions = list(data["versions"].keys())
+            log.debug(f"Retrieved versions {', '.join(versions)}")
+            result = set()
+            try:
+                npm_spec = NpmSpec(semver_range)
+            except ValueError:  # not a semver range, let's keep it raw
+                result.add(semver_range)
+                return result
+            for v in versions:
+                if Version(v) in npm_spec:
+                    result.add(v)
+
+            # If just the best matched version scan is required we only keep one
+            if not VERIFY_ALL_DEPENDENCIES and result:
+                result = set([sorted(result).pop()])
+
+            return result
 
         merged = {}  # type: dict[str, set[str]]
-        for package, selector in list(dependencies.items()) + list(dev_dependencies.items()):
+        for package, selector in list(dependencies.items()) + list(
+            dev_dependencies.items()
+        ):
             if package not in merged:
                 merged[package] = set()
             merged[package].add(selector)

--- a/guarddog/scanners/npm_project_scanner.py
+++ b/guarddog/scanners/npm_project_scanner.py
@@ -1,15 +1,13 @@
 import json
 import logging
-import os
 import requests
 from semantic_version import NpmSpec, Version  # type:ignore
 
+from guarddog.utils.config import VERIFY_EXHAUSTIVE_DEPENDENCIES
 from guarddog.scanners.npm_package_scanner import NPMPackageScanner
 from guarddog.scanners.scanner import ProjectScanner
 
 log = logging.getLogger("guarddog")
-# This flag spedificies if an analysis of all posible versions is required
-VERIFY_ALL_DEPENDENCIES = os.environ.get("GUARDDOG_VERIFY_ALL_DEPENDENCIES", False)
 
 
 class NPMRequirementsScanner(ProjectScanner):
@@ -72,7 +70,7 @@ class NPMRequirementsScanner(ProjectScanner):
                     result.add(v)
 
             # If just the best matched version scan is required we only keep one
-            if not VERIFY_ALL_DEPENDENCIES and result:
+            if not VERIFY_EXHAUSTIVE_DEPENDENCIES and result:
                 result = set([sorted(result).pop()])
 
             return result

--- a/guarddog/scanners/pypi_project_scanner.py
+++ b/guarddog/scanners/pypi_project_scanner.py
@@ -7,10 +7,11 @@ import requests
 
 from guarddog.scanners.pypi_package_scanner import PypiPackageScanner
 from guarddog.scanners.scanner import ProjectScanner
-from packaging.requirements import Requirement
+from packaging.specifiers import Specifier
 
 log = logging.getLogger("guarddog")
 
+# This flag spedificies if an analysis of all posible versions is required
 VERIFY_ALL_DEPENDENCIES = os.environ.get("GUARDDOG_VERIFY_ALL_DEPENDENCIES", False)
 
 
@@ -50,14 +51,13 @@ class PypiRequirementsScanner(ProjectScanner):
 
         return sanitized_lines
 
-    # FIXME: type return value properly to dict[str, set[str]]
-    def parse_requirements(self, raw_requirements: str) -> dict:
+    def parse_requirements(self, raw_requirements: str) -> dict[str, set[str]]:
         """
         Parses requirements.txt specification and finds all valid
         versions of each dependency
 
         Args:
-            raw_requirements (List[str]): contents of requirements.txt file
+            raw_requirements (str): contents of requirements.txt file
 
         Returns:
             dict: mapping of dependencies to valid versions
@@ -71,18 +71,37 @@ class PypiRequirementsScanner(ProjectScanner):
         """
         requirements = raw_requirements.splitlines()
 
-        def versions(package_name):
+        def find_all_versions(package_name: str, semver_range: str) -> set[str]:
+            """
+            This helper function retrieves all available version of a package
+            """
             url = "https://pypi.org/pypi/%s/json" % (package_name,)
             log.debug(f"Retrieving PyPI package metadata information from {url}")
             data = requests.get(url).json()
             versions = sorted(data["releases"].keys(), reverse=True)
-            return versions
+
+            # Filters to specified versions
+            try:
+                spec = Specifier(semver_range)
+                result = [m for m in spec.filter(versions)]
+            except ValueError:
+                # keep it raw
+                result = [semver_range]
+
+            # If just the best matched version scan is required we only keep one
+            if not VERIFY_ALL_DEPENDENCIES and result:
+                result = [sorted(result).pop()]
+
+            return set(result)
 
         sanitized_requirements = self._sanitize_requirements(requirements)
 
         dependencies = {}
 
         def safe_parse_requirements(req):
+            """
+            This helper function yields one valid requirement line at a time
+            """
             parsed = pkg_resources.parse_requirements(req)
             while True:
                 try:
@@ -100,12 +119,17 @@ class PypiRequirementsScanner(ProjectScanner):
             for requirement in safe_parse_requirements(sanitized_requirements):
                 if requirement is None:
                     continue
-                valid_versions = None
+
                 project_exists_on_pypi = True
                 try:
-                    available_versions = versions(
-                        requirement.project_name
-                    )  # type: list[str]
+                    versions = find_all_versions(
+                        requirement.project_name,
+                        (
+                            requirement.url
+                            if requirement.url
+                            else str(requirement.specifier)
+                        ),
+                    )
                 except Exception:
                     sys.stderr.write(
                         f"Package {requirement.project_name} not on PyPI\n"
@@ -113,15 +137,8 @@ class PypiRequirementsScanner(ProjectScanner):
                     project_exists_on_pypi = False
                     continue
 
-                r = Requirement(str(requirement))
-
-                matched_versions = [m for m in r.specifier.filter(available_versions)]
-
-                if not VERIFY_ALL_DEPENDENCIES and matched_versions:
-                    matched_versions = [sorted(matched_versions).pop()]
-
                 if project_exists_on_pypi:
-                    dependencies[requirement.project_name] = set(matched_versions)
+                    dependencies[requirement.project_name] = versions
         except Exception as e:
             sys.stderr.write(f"Received error {str(e)}")
 

--- a/guarddog/scanners/pypi_project_scanner.py
+++ b/guarddog/scanners/pypi_project_scanner.py
@@ -139,7 +139,7 @@ class PypiRequirementsScanner(ProjectScanner):
 
                 if len(versions) == 0:
                     log.error(
-                        f"Package/Version {requirement.project_name} not on NPM\n"
+                        f"Package/Version {requirement.project_name} not on PyPI\n"
                     )
                     continue
 

--- a/guarddog/scanners/pypi_project_scanner.py
+++ b/guarddog/scanners/pypi_project_scanner.py
@@ -1,18 +1,15 @@
 import logging
 import re
 import sys
-import os
 import pkg_resources
 import requests
+from packaging.specifiers import Specifier
 
 from guarddog.scanners.pypi_package_scanner import PypiPackageScanner
 from guarddog.scanners.scanner import ProjectScanner
-from packaging.specifiers import Specifier
+from guarddog.utils.config import VERIFY_EXHAUSTIVE_DEPENDENCIES
 
 log = logging.getLogger("guarddog")
-
-# This flag spedificies if an analysis of all posible versions is required
-VERIFY_ALL_DEPENDENCIES = os.environ.get("GUARDDOG_VERIFY_ALL_DEPENDENCIES", False)
 
 
 class PypiRequirementsScanner(ProjectScanner):
@@ -89,7 +86,7 @@ class PypiRequirementsScanner(ProjectScanner):
                 result = [semver_range]
 
             # If just the best matched version scan is required we only keep one
-            if not VERIFY_ALL_DEPENDENCIES and result:
+            if not VERIFY_EXHAUSTIVE_DEPENDENCIES and result:
                 result = [sorted(result).pop()]
 
             return set(result)

--- a/guarddog/scanners/scanner.py
+++ b/guarddog/scanners/scanner.py
@@ -1,16 +1,14 @@
 import concurrent.futures
 import json
 import logging
-import multiprocessing
 import os
 import sys
 import tempfile
 import typing
 from abc import abstractmethod
 from concurrent.futures import ThreadPoolExecutor
-
 import requests
-
+from guarddog.utils.config import PARALLELISM
 from guarddog.utils.archives import safe_extract
 
 log = logging.getLogger("guarddog")
@@ -92,10 +90,7 @@ class ProjectScanner(Scanner):
             return {"dependency": dependency, "version": version, "result": result}
 
         dependencies = self.parse_requirements(requirements)
-
-        num_workers = multiprocessing.cpu_count()
-        if os.environ.get("GUARDDOG_PARALLELISM") is not None:
-            num_workers = int(os.environ["GUARDDOG_PARALLELISM"])
+        num_workers = PARALLELISM
 
         sys.stderr.write(
             f"Scanning using at most {num_workers} parallel worker threads\n"

--- a/guarddog/utils/config.py
+++ b/guarddog/utils/config.py
@@ -1,0 +1,30 @@
+import os
+import multiprocessing
+
+"""
+This parameter specifies the amount of threads to use while requiring parallelism
+- Default: Number of CPUs available
+"""
+PARALLELISM: int = int(
+    os.environ.get("GUARDDOG_PARALLELISM", multiprocessing.cpu_count())
+)
+
+"""
+This flag specifies if an analysis of all posible versions is required
+- True: All possible versions are analyzed
+- False [default]: Only best match is analyzed
+"""
+VERIFY_EXHAUSTIVE_DEPENDENCIES: bool = (
+    os.environ.get("GUARDDOG_VERIFY_EXHAUSTIVE_DEPENDENCIES", "false").lower() == "true"
+)
+
+"""
+This parameter specifies the location of the top packages cache
+- Default: guarddog/analyzer/metadata/resources
+"""
+TOP_PACKAGES_CACHE_LOCATION = os.environ.get(
+    "GUARDDOG_TOP_PACKAGES_CACHE_LOCATION",
+    os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "../analyzer/metadata/resources")
+    ),
+)

--- a/tests/core/test_pypi_requirements_scanner.py
+++ b/tests/core/test_pypi_requirements_scanner.py
@@ -1,11 +1,12 @@
-
 from guarddog.scanners.pypi_project_scanner import PypiRequirementsScanner
 
 
 # Regression test for https://github.com/DataDog/guarddog/issues/78
 def test_requirements_scanner():
     scanner = PypiRequirementsScanner()
-    result = scanner.parse_requirements("\n".join(["not-a-real-package==1.0.0", "flask==2.2.2"]))
+    result = scanner.parse_requirements(
+        "\n".join(["not-a-real-package==1.0.0", "flask==2.2.2"])
+    )
     assert "not-a-real-package" not in result  # ignoring non existing packages
     assert "flask" in result
 
@@ -13,12 +14,17 @@ def test_requirements_scanner():
 # Regression test for https://github.com/DataDog/guarddog/issues/88
 def test_requirements_scanner_on_git_url_packages():
     scanner = PypiRequirementsScanner()
-    result = scanner.parse_requirements("\n".join([
-        "flask==2.2.2",
-        "https://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl",
-        "guarddog @ git+https://github.com/DataDog/guarddog.git",
-        "git+https://github.com/DataDog/guarddog.git"
-    ]))
+    result = scanner.parse_requirements(
+        "\n".join(
+            [
+                "flask==2.2.2",
+                "https://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl",
+                "guarddog @ git+https://github.com/DataDog/guarddog.git",
+                "git+https://github.com/DataDog/guarddog.git",
+            ]
+        )
+    )
     assert "guarddog" in result
+    assert "git+https://github.com/DataDog/guarddog.git" in result["guarddog"]
     assert "flask" in result
     assert len(result) == 2


### PR DESCRIPTION
closes issue https://github.com/DataDog/guarddog/issues/362
closes issue https://github.com/DataDog/guarddog/issues/262
closes issue https://github.com/DataDog/guarddog/issues/86

**Context**
Guarddog verify command operated against all possible matches of packages. 
So for instance a requirement with `guarddog>=1.0.0`
would result in guarddog verifying all possible matches:
```- 1.0.0
- 1.0.1
- 1.0.2
- ... 
```
This behaviour could lead to a very lengthy scan process and most-likely not the most useful given that only the most recent match is installed by package managers
 
**Changes**
This PR modifies that behaviour to select by default the best "match" (like a real package manager would do)
So, having the following requirement `guarddog>=1.0.0`
Would result for selecting the latest matched version, e.g: `1.9.0`

IMPORTANT: This default behaviour can be overiden setting the environment flag `GUARDDOG_VERIFY_EXHAUSTIVE_DEPENDENCIES` to "True"