### PR TITLE
Add exception for wrong JSFuck detection

### DIFF
--- a/guarddog/analyzer/sourcecode/npm-obfuscation.yml
+++ b/guarddog/analyzer/sourcecode/npm-obfuscation.yml
@@ -57,6 +57,8 @@ rules:
         # JSFuck 
         - patterns:
           - pattern-not-inside: "..."
+          - pattern-not-inside: /*...*/
+          - pattern-not-inside: //...
           - pattern-regex: ^\s*[\[\]\(\)\+\!]{10,}\s*$
     languages:
       - javascript

--- a/tests/analyzer/sourcecode/npm-obfuscation.js
+++ b/tests/analyzer/sourcecode/npm-obfuscation.js
@@ -154,6 +154,7 @@ function f(){
     self[k(i)](urlTo);
 }
 
+/* OK: only JSFuck charactes in static data */
 function f(){
     // ok: npm-obfuscation
     console.warn(`
@@ -168,4 +169,19 @@ function f(){
     dependencies on both your server and clients.
     
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!`);
+}
+
+/* OK: only JSFuck charactes in static data */
+function f(){
+    
+/*
+button component option
+ variant = text , contained , outlined
+// ok: npm-obfuscation
+ ++++++++++++++
+ text button 
+ // ok: npm-obfuscation
+ ++++++++++++++
+ disabled
+*/
 }


### PR DESCRIPTION
The following comment triggered the detection by error:
```
/*
button component option
 variant = text , contained , outlined
 ++++++++++++++
 text button 
 // ok: npm-obfuscation
 ++++++++++++++
 disabled
*/
```

This PR escapes comments in the detection