### PR TITLE
Fixing the timezone in dns lookups

### DIFF
--- a/guarddog/analyzer/metadata/npm/potentially_compromised_email_domain.py
+++ b/guarddog/analyzer/metadata/npm/potentially_compromised_email_domain.py
@@ -3,27 +3,35 @@
 Detects if a maintainer's email domain might have been compromised.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 from dateutil import parser
 
-from guarddog.analyzer.metadata.potentially_compromised_email_domain import PotentiallyCompromisedEmailDomainDetector
+from guarddog.analyzer.metadata.potentially_compromised_email_domain import \
+    PotentiallyCompromisedEmailDomainDetector
 
 from .utils import NPM_API_MAINTAINER_EMAIL_WARNING, get_email_addresses
 
 
-class NPMPotentiallyCompromisedEmailDomainDetector(PotentiallyCompromisedEmailDomainDetector):
+class NPMPotentiallyCompromisedEmailDomainDetector(
+    PotentiallyCompromisedEmailDomainDetector
+):
     def __init__(self):
         super().__init__("npm")
 
         self.description += "; " + NPM_API_MAINTAINER_EMAIL_WARNING
 
-    def get_email_addresses(self, package_info: dict):
+    def get_email_addresses(self, package_info: dict) -> set[str]:
         return get_email_addresses(package_info)
 
-    def detect(self, package_info, path: Optional[str] = None, name: Optional[str] = None,
-               version: Optional[str] = None) -> tuple[bool, str]:
+    def detect(
+        self,
+        package_info,
+        path: Optional[str] = None,
+        name: Optional[str] = None,
+        version: Optional[str] = None,
+    ) -> tuple[bool, str]:
         has_issues, message = super().detect(package_info, path, name, version)
 
         if has_issues:
@@ -43,5 +51,5 @@ class NPMPotentiallyCompromisedEmailDomainDetector(PotentiallyCompromisedEmailDo
         """
         latest_release_version = package_info["dist-tags"]["latest"]
         raw_date = package_info["time"][latest_release_version]
-        release_date = parser.isoparse(raw_date).replace(tzinfo=None)
+        release_date = parser.isoparse(raw_date).replace(tzinfo=timezone.utc)
         return release_date

--- a/guarddog/analyzer/metadata/npm/unclaimed_maintainer_email_domain.py
+++ b/guarddog/analyzer/metadata/npm/unclaimed_maintainer_email_domain.py
@@ -1,5 +1,7 @@
 from typing import Optional
-from guarddog.analyzer.metadata.unclaimed_maintainer_email_domain import UnclaimedMaintainerEmailDomainDetector
+
+from guarddog.analyzer.metadata.unclaimed_maintainer_email_domain import \
+    UnclaimedMaintainerEmailDomainDetector
 
 from .utils import NPM_API_MAINTAINER_EMAIL_WARNING, get_email_addresses
 
@@ -10,11 +12,16 @@ class NPMUnclaimedMaintainerEmailDomainDetector(UnclaimedMaintainerEmailDomainDe
 
         self.description += "; " + NPM_API_MAINTAINER_EMAIL_WARNING
 
-    def get_email_addresses(self, package_info: dict):
+    def get_email_addresses(self, package_info: dict) -> set[str]:
         return get_email_addresses(package_info)
 
-    def detect(self, package_info, path: Optional[str] = None, name: Optional[str] = None,
-               version: Optional[str] = None) -> tuple[bool, str]:
+    def detect(
+        self,
+        package_info,
+        path: Optional[str] = None,
+        name: Optional[str] = None,
+        version: Optional[str] = None,
+    ) -> tuple[bool, str]:
         has_issues, message = super().detect(package_info, path, name, version)
 
         if has_issues:

--- a/guarddog/analyzer/metadata/potentially_compromised_email_domain.py
+++ b/guarddog/analyzer/metadata/potentially_compromised_email_domain.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+from datetime import datetime
 from typing import Optional
 
 from guarddog.analyzer.metadata.detector import Detector
@@ -12,12 +13,17 @@ class PotentiallyCompromisedEmailDomainDetector(Detector):
         super().__init__(
             name="potentially_compromised_email_domain",
             description="Identify when a package maintainer e-mail domain (and therefore package manager account) "
-                        "might have been compromised",
+            "might have been compromised",
         )
         self.ecosystem = ecosystem
 
-    def detect(self, package_info, path: Optional[str] = None, name: Optional[str] = None,
-               version: Optional[str] = None) -> tuple[bool, str]:
+    def detect(
+        self,
+        package_info,
+        path: Optional[str] = None,
+        name: Optional[str] = None,
+        version: Optional[str] = None,
+    ) -> tuple[bool, str]:
         """
         Uses a package's information to determine
         if the maintainer's email domain might have been compromised
@@ -54,16 +60,21 @@ class PotentiallyCompromisedEmailDomainDetector(Detector):
                 has_issues = True
 
                 messages.append(
-                    f"The domain name of the maintainer's email address ({email}) was"" re-registered after"
-                    " the latest release of this ""package. This can be an indicator that this is a"""
-                    " custom domain that expired, and was leveraged by"" an attacker to compromise the"
-                    f" package owner's {self.ecosystem}"" account."
+                    f"The domain name of the maintainer's email address ({email}) was"
+                    " re-registered after"
+                    " the latest release of this "
+                    "package. This can be an indicator that this is a"
+                    ""
+                    " custom domain that expired, and was leveraged by"
+                    " an attacker to compromise the"
+                    f" package owner's {self.ecosystem}"
+                    " account."
                 )
 
         return has_issues, "\n".join(messages)
 
     @abstractmethod
-    def get_project_latest_release_date(self, package_info):
+    def get_project_latest_release_date(self, package_info) -> Optional[datetime]:
         pass
 
     @abstractmethod

--- a/guarddog/analyzer/metadata/potentially_compromised_email_domain.py
+++ b/guarddog/analyzer/metadata/potentially_compromised_email_domain.py
@@ -60,15 +60,10 @@ class PotentiallyCompromisedEmailDomainDetector(Detector):
                 has_issues = True
 
                 messages.append(
-                    f"The domain name of the maintainer's email address ({email}) was"
-                    " re-registered after"
-                    " the latest release of this "
-                    "package. This can be an indicator that this is a"
-                    ""
-                    " custom domain that expired, and was leveraged by"
-                    " an attacker to compromise the"
-                    f" package owner's {self.ecosystem}"
-                    " account."
+                    f"The domain name of the maintainer's email address ({email}) was"" re-registered after"
+                    " the latest release of this ""package. This can be an indicator that this is a"
+                    " custom domain that expired, and was leveraged by"" an attacker to compromise the"
+                    f" package owner's {self.ecosystem}"" account."
                 )
 
         return has_issues, "\n".join(messages)

--- a/guarddog/analyzer/metadata/pypi/potentially_compromised_email_domain.py
+++ b/guarddog/analyzer/metadata/pypi/potentially_compromised_email_domain.py
@@ -2,18 +2,22 @@
 
 Detects if a maintainer's email domain might have been compromised.
 """
-from datetime import datetime
+
+from datetime import datetime, timezone
 from typing import Optional
 
 from dateutil import parser
 from packaging import version
 
-from guarddog.analyzer.metadata.potentially_compromised_email_domain import PotentiallyCompromisedEmailDomainDetector
+from guarddog.analyzer.metadata.potentially_compromised_email_domain import \
+    PotentiallyCompromisedEmailDomainDetector
 
 from .utils import get_email_addresses
 
 
-class PypiPotentiallyCompromisedEmailDomainDetector(PotentiallyCompromisedEmailDomainDetector):
+class PypiPotentiallyCompromisedEmailDomainDetector(
+    PotentiallyCompromisedEmailDomainDetector
+):
     def __init__(self):
         super().__init__("pypi")
 
@@ -34,13 +38,17 @@ class PypiPotentiallyCompromisedEmailDomainDetector(PotentiallyCompromisedEmailD
         sorted_versions = sorted(
             releases.keys(), key=lambda r: version.parse(r), reverse=True
         )
-        earlier_versions = sorted_versions[:-1] if len(sorted_versions) > 1 else sorted_versions
+        earlier_versions = (
+            sorted_versions[:-1] if len(sorted_versions) > 1 else sorted_versions
+        )
 
         for early_version in earlier_versions:
             version_release = releases[early_version]
 
             if len(version_release) > 0:  # if there's a distribution for the package
                 upload_time_text = version_release[0]["upload_time_iso_8601"]
-                release_date = parser.isoparse(upload_time_text).replace(tzinfo=None)
+                release_date = parser.isoparse(upload_time_text).replace(
+                    tzinfo=timezone.utc
+                )
                 return release_date
         raise Exception("could not find release date")

--- a/guarddog/analyzer/metadata/utils.py
+++ b/guarddog/analyzer/metadata/utils.py
@@ -41,7 +41,7 @@ def get_domain_creation_date(domain) -> tuple[Optional[datetime], bool]:
         # TZ info is updated to turn all dates into TZ aware so we can compare them
         return min([d.replace(tzinfo=timezone.utc) for d in creation_dates]), True
 
-    return creation_dates, True
+    return creation_dates.replace(tzinfo=timezone.utc), True
 
 
 def extract_email_address_domain(email_address: str):


### PR DESCRIPTION
closes https://github.com/DataDog/guarddog/issues/387

The `potentially_compromised_email_domain` rule was producing results when comparing registration dates for some domains such as gmail.com

* potentially_compromised_email_domain: failed to run rule unclaimed_maintainer_email_domain: can't compare offset-naive and offset-aware datetimes

This PR forces to use timezone awareness to all obtained dates in order to compare them