### PR TITLE
add --version flag to cli

### DIFF
--- a/guarddog/cli.py
+++ b/guarddog/cli.py
@@ -134,6 +134,7 @@ def logging_options(fn):
 
 @click.group
 @logging_options
+@click.version_option(message="%(version)s")
 def cli(log_level):
     """
     GuardDog cli tool to detect malware in package ecosystems


### PR DESCRIPTION
Adds a `--version` flag to the cli for retrival of the GuardDog version.

The actual version detection depends on the packaging. I tried to test this, but it should be reviewed again upon release.
Results are as follows:

* I tested setting the version via `pyproject.toml` by which it is automatically detected:
```bash
❯ poetry run guarddog --version
1.10.0
```

* I briefly made a release check by downloading the current [.tar.gz from pypi](https://pypi.org/project/guarddog/#files) and injected the change from this PR, repackaged, and installed via `pip install guarddog-1.10.0.tar.gz`:

```bash
❯ guarddog
Usage: guarddog [OPTIONS] COMMAND [ARGS]...

  GuardDog cli tool to detect malware in package ecosystems

  Supports PyPI and npm

  Example: guarddog pypi scan semantic-version

  Use --help for the detail of all commands and subcommands

Options:
  --log-level [ERROR|DEBUG|INFO|WARNING]
  --version                       Show the version and exit.
  --help                          Show this message and exit.

Commands:
  npm     Scan a npm package or verify a npm project
  pypi    Scan a PyPI package or verify a PyPI project
  scan    (Deprecated)
  verify  (Deprecated)
```
And:
```bash
❯ guarddog --version
1.10.0
```

So, I'd assume this works on released packages.