### PR TITLE
Bugfix: Input rules are not correctly set in analyzers

### DIFF
--- a/guarddog/analyzer/analyzer.py
+++ b/guarddog/analyzer/analyzer.py
@@ -57,6 +57,27 @@ class Analyzer:
             ".semgrep_logs",
         ]
 
+    def get_rules(self, rules=None):
+      # populate results, errors, and number of issues
+        metadata_rules = None
+        sourcecode_rules = None
+        if rules is not None:
+            # Only run specific rules
+            sourcecode_rules = set()
+            metadata_rules = set()
+
+            for rule in rules:
+                if rule in self.sourcecode_ruleset:
+                    log.debug(f"Using source code rule {rule}")
+                    sourcecode_rules.add(rule)
+                elif rule in self.metadata_ruleset:
+                    log.debug(f"Using metadata rule {rule}")
+                    metadata_rules.add(rule)
+                else:
+                    raise Exception(f"{rule} is not a valid rule.")
+        return sourcecode_rules, metadata_rules
+
+
     def analyze(self, path, info=None, rules=None, name: Optional[str] = None, version: Optional[str] = None) -> dict:
         """
         Analyzes a package in the given path
@@ -77,23 +98,8 @@ class Analyzer:
         sourcecode_results = None
 
         # populate results, errors, and number of issues
-        metadata_rules = None
-        sourcecode_rules = None
-        if rules is not None:
-            # Only run specific rules
-            sourcecode_rules = set()
-            metadata_rules = set()
-
-            for rule in rules:
-                if rule in self.sourcecode_ruleset:
-                    log.debug(f"Using source code rule {rule}")
-                    sourcecode_rules.add(rule)
-                elif rule in self.metadata_ruleset:
-                    log.debug(f"Using metadata rule {rule}")
-                    metadata_rules.add(rule)
-                else:
-                    raise Exception(f"{rule} is not a valid rule.")
-
+        sourcecode_rules, metadata_rules = self.get_rules(rules)
+        
         log.debug(f"Running metadata rules against package '{name}'")
         metadata_results = self.analyze_metadata(path, info, metadata_rules, name, version)
 

--- a/guarddog/scanners/scanner.py
+++ b/guarddog/scanners/scanner.py
@@ -10,6 +10,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 import requests
 
+from guarddog.analyzer.analyzer import Analyzer
 from guarddog.utils.archives import safe_extract
 from guarddog.utils.config import PARALLELISM
 
@@ -219,7 +220,7 @@ class PackageScanner(Scanner):
         analyzer (Analyzer): Analyzer for source code and metadata rules
     """
 
-    def __init__(self, analyzer):
+    def __init__(self, analyzer: Analyzer):
         super().__init__()
         self.analyzer = analyzer
 
@@ -248,17 +249,15 @@ class PackageScanner(Scanner):
         if not os.path.exists(path):
             raise Exception(f"Path {path} does not exist.")
 
-        sourcecode_rules, _ = self.analyzer.get_rules(rules)
-
         if any(path.endswith(ext) for ext in (".tar.gz", ".tgz", ".zip", ".whl")):
             with tempfile.TemporaryDirectory() as tmpdirname:
                 safe_extract(path, tmpdirname)
                 return self.analyzer.analyze_sourcecode(
-                    tmpdirname, rules=sourcecode_rules
+                    tmpdirname, rules=rules
                 )
 
         if os.path.isdir(path):
-            return self.analyzer.analyze_sourcecode(path, rules=sourcecode_rules)
+            return self.analyzer.analyze_sourcecode(path, rules=rules)
 
         raise Exception(
             f"Path {path} is not a directory nor an archive type supported by GuardDog."

--- a/guarddog/scanners/scanner.py
+++ b/guarddog/scanners/scanner.py
@@ -7,9 +7,11 @@ import tempfile
 import typing
 from abc import abstractmethod
 from concurrent.futures import ThreadPoolExecutor
+
 import requests
-from guarddog.utils.config import PARALLELISM
+
 from guarddog.utils.archives import safe_extract
+from guarddog.utils.config import PARALLELISM
 
 log = logging.getLogger("guarddog")
 
@@ -246,13 +248,17 @@ class PackageScanner(Scanner):
         if not os.path.exists(path):
             raise Exception(f"Path {path} does not exist.")
 
+        sourcecode_rules, _ = self.analyzer.get_rules(rules)
+
         if any(path.endswith(ext) for ext in (".tar.gz", ".tgz", ".zip", ".whl")):
             with tempfile.TemporaryDirectory() as tmpdirname:
                 safe_extract(path, tmpdirname)
-                return self.analyzer.analyze_sourcecode(tmpdirname, rules=rules)
+                return self.analyzer.analyze_sourcecode(
+                    tmpdirname, rules=sourcecode_rules
+                )
 
         if os.path.isdir(path):
-            return self.analyzer.analyze_sourcecode(path, rules=rules)
+            return self.analyzer.analyze_sourcecode(path, rules=sourcecode_rules)
 
         raise Exception(
             f"Path {path} is not a directory nor an archive type supported by GuardDog."


### PR DESCRIPTION
**Situation:**
The situation occurs when the user excludes a rule using the `-x` switch while scanning a local package.

**Explaination:**
The program attempts to only run sourcecode rules on a folder but the rules are not correctly set. 

**Result:**
The program produces an error while trying to load semgrep rules using metadata rule names.

```
poetry run guarddog npm scan /tmp/sample.tar.gz --output-format=json -x npm-dll-hijacking
{ ...
"errors": {"rules-all": "failed to run rule: \nAn error occurred when running Semgrep....
`...guarddog/analyzer/sourcecode/direct_url_dependency.yml` does not exist\", \"type\": \"SemgrepError\"}
`.../guarddog/analyzer/sourcecode/npm_metadata_mismatch.yml` does not exist\", \"type\": \"SemgrepError\"}
```