### PR TITLE
Hotfix: No rules are ran by default 

### DIFF
--- a/guarddog/cli.py
+++ b/guarddog/cli.py
@@ -4,11 +4,11 @@ CLI command that scans a PyPI package version for user-specified malware flags.
 Includes rules based on package registry metadata and source code analysis.
 """
 
+import json as js
 import logging
 import os
 import sys
-from typing import cast, Optional
-import json as js
+from typing import Optional, cast
 
 import click
 from prettytable import PrettyTable
@@ -153,7 +153,9 @@ def cli(log_level):
     pass
 
 
-def _get_rule_param(rules: tuple[str, ...], exclude_rules: tuple[str, ...], ecosystem: ECOSYSTEM) -> Optional[set]:
+def _get_rule_param(
+    rules: tuple[str, ...], exclude_rules: tuple[str, ...], ecosystem: ECOSYSTEM
+) -> Optional[set]:
     """
     This function should return None if no rules are provided
     Else a set of rules to be used for scanning

--- a/guarddog/cli.py
+++ b/guarddog/cli.py
@@ -153,8 +153,12 @@ def cli(log_level):
     pass
 
 
-def _get_rule_param(rules: tuple[str, ...], exclude_rules: tuple[str, ...], ecosystem: ECOSYSTEM) -> set:
-    rule_param = set()
+def _get_rule_param(rules: tuple[str, ...], exclude_rules: tuple[str, ...], ecosystem: ECOSYSTEM) -> Optional[set]:
+    """
+    This function should return None if no rules are provided
+    Else a set of rules to be used for scanning
+    """
+    rule_param = None
     if len(rules) > 0:
         rule_param = set(rules)
 

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -30,7 +30,7 @@ def test_get_rule_param_include():
 
 def test_get_rule_param_exclude():
     """
-    Test the parsing function returns returns a list without the excluded parameter
+    Test the parsing function returns a list without the excluded parameter
     """
     rules = guarddog.cli._get_rule_param((), ("shady-links",), ECOSYSTEM.PYPI)
     assert rules
@@ -39,7 +39,7 @@ def test_get_rule_param_exclude():
 
 def test_get_rule_param_empty():
     """
-    Test the parsing function returns returns a list without the excluded parameter
+    Test the parsing function returns None when no rules are provided
     """
     rules = guarddog.cli._get_rule_param((), (), ECOSYSTEM.PYPI)
     assert rules is None

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -24,13 +24,22 @@ def test_get_rule_param_include():
     """
     Test the parsing function returns the included parameter
     """
-    assert len(guarddog.cli._get_rule_param(("shady-links",), (), ECOSYSTEM.NPM)) == 1
-
+    rules = guarddog.cli._get_rule_param(("shady-links",), (), ECOSYSTEM.NPM)
+    assert rules
+    assert len(rules) == 1
 
 def test_get_rule_param_exclude():
     """
     Test the parsing function returns returns a list without the excluded parameter
     """
     rules = guarddog.cli._get_rule_param((), ("shady-links",), ECOSYSTEM.PYPI)
+    assert rules
     assert len(rules) != 1
     assert "shady-links" not in rules
+
+def test_get_rule_param_empty():
+    """
+    Test the parsing function returns returns a list without the excluded parameter
+    """
+    rules = guarddog.cli._get_rule_param((), (), ECOSYSTEM.PYPI)
+    assert rules is None


### PR DESCRIPTION
Version v1.11.1 introduced a bug that produced that no rule is assigned to run by default