### PR TITLE
Remove duplicated sourcode findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,16 @@ Metadata heuristics:
 
 <!-- END_RULE_LIST -->
 
+## Custom Rules
+
+Guarddog allows to implement custom sourcecode rules.
+Sourcecode rules live under the [guarddog/analyzer/sourcecode](guarddog/analyzer/sourcecode) directory, and supported formats are [Semgrep](https://github.com/semgrep/semgrep) or [Yara](https://github.com/VirusTotal/yara).
+
+* Semgrep rules are language-dependent, and Guarddog will import all `.yml` rules where the language matches the ecosystem selected by the user in CLI.
+* Yara rules on the other hand are language agnostic, therefore all matching `.yar` rules present will be imported.
+
+Is possible then to write your own rule and drop it into that directory, Guarddog will allow you to select it or exclude it as any built-in rule as well as appending the findings to its output.
+
 ## Running GuardDog in a GitHub Action
 
 The easiest way to integrate GuardDog in your CI pipeline is to leverage the SARIF output format, and upload it to GitHub's [code scanning](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/about-code-scanning) feature.

--- a/README.md
+++ b/README.md
@@ -148,16 +148,6 @@ Metadata heuristics:
 
 <!-- END_RULE_LIST -->
 
-## Custom Rules
-
-Guarddog allows to implement custom sourcecode rules.
-Sourcecode rules live under the [guarddog/analyzer/sourcecode](guarddog/analyzer/sourcecode) directory, and supported formats are [Semgrep](https://github.com/semgrep/semgrep) or [Yara](https://github.com/VirusTotal/yara).
-
-* Semgrep rules are language-dependent, and Guarddog will import all `.yml` rules where the language matches the ecosystem selected by the user in CLI.
-* Yara rules on the other hand are language agnostic, therefore all matching `.yar` rules present will be imported.
-
-Is possible then to write your own rule and drop it into that directory, Guarddog will allow you to select it or exclude it as any built-in rule as well as appending the findings to its output.
-
 ## Running GuardDog in a GitHub Action
 
 The easiest way to integrate GuardDog in your CI pipeline is to leverage the SARIF output format, and upload it to GitHub's [code scanning](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/about-code-scanning) feature.

--- a/guarddog/analyzer/analyzer.py
+++ b/guarddog/analyzer/analyzer.py
@@ -240,11 +240,16 @@ output: {e.output}
             location = file_path + ":" + str(line)
             code = self.trim_code_snippet(code_snippet)
 
-            results[rule_name].append({
+            finding = {
                 'location': location,
                 'code': code,
                 'message': result["extra"]["message"]
-            })
+            }
+
+            rule_results = results[rule_name]
+            if finding in rule_results:
+                continue
+            results[rule_name].append(finding)
 
         return results
 


### PR DESCRIPTION
By the nature of how semgrep works, some of our rules (like obfuscation, shady-links, etc) would find multiple times the same offending line. 
This might lead to report the location and code over and over again.
This PR aims to only append a finding if not already reported.

From this:
```
shady-links: found 951 source code matches
  * This package contains an URL to a domain with a suspicious extension at package/lib/index.cjs:1
        "use strict";var Kc=Object.create;var vn=Object.defineProperty;var Jc=Object.getOwnPropertyDescriptor;var Qc=Object.getOwnPropertyNames;var Yc=Object.getPrototypeOf,Zc=Object.prototype.hasOwnProperty;var ee=(t,e)=>{for(var r in e)vn(t,r,{ge...}`).join(`
  * This package contains an URL to a domain with a suspicious extension at package/lib/index.cjs:1
        "use strict";var Kc=Object.create;var vn=Object.defineProperty;var Jc=Object.getOwnPropertyDescriptor;var Qc=Object.getOwnPropertyNames;var Yc=Object.getPrototypeOf,Zc=Object.prototype.hasOwnProperty;var ee=(t,e)=>{for(var r in e)vn(t,r,{ge...}`).join(`
  * This package contains an URL to a domain with a suspicious extension at package/lib/index.cjs:1
        "use strict";var Kc=Object.create;var vn=Object.defineProperty;var Jc=Object.getOwnPropertyDescriptor;var Qc=Object.getOwnPropertyNames;var Yc=Object.getPrototypeOf,Zc=Object.prototype.hasOwnProperty;var ee=(t,e)=>{for(var r in e)vn(t,r,{ge...}`).join(`
  * This package contains an URL to a domain with a suspicious extension at package/lib/index.cjs:1
        "use strict";var Kc=Object.create;var vn=Object.defineProperty;var Jc=Object.getOwnPropertyDescriptor;var Qc=Object.getOwnPropertyNames;var Yc=Object.getPrototypeOf,Zc=Object.prototype.hasOwnProperty;var ee=(t,e)=>{for(var r in e)vn(t,r,{ge...}`).join(`
  * This package contains an URL to a domain with a suspicious extension at package/lib/index.cjs:1
        "use strict";var Kc=Object.create;var vn=Object.defineProperty;var Jc=Object.getOwnPropertyDescriptor;var Qc=Object.getOwnPropertyNames;var Yc=Object.getPrototypeOf,Zc=Object.prototype.hasOwnProperty;var ee=(t,e)=>{for(var r in e)vn(t,r,{ge...}`).join(`
  * This package contains an URL to a domain with a suspicious extension at package/lib/index.cjs:1
        "use strict";var Kc=Object.create;var vn=Object.defineProperty;var Jc=Object.getOwnPropertyDescriptor;var Qc=Object.getOwnPropertyNames;var Yc=Object.getPrototypeOf,Zc=Object.prototype.hasOwnProperty;var ee=(t,e)=>{for(var r in e)vn(t,r,{ge...}`).join(`
  * This package contains an URL to a domain with a suspicious extension at package/lib/index.cjs:1
        "use strict";var Kc=Object.create;var vn=Object.defineProperty;var Jc=Object.getOwnPropertyDescriptor;var Qc=Object.getOwnPropertyNames;var Yc=Object.getPrototypeOf,Zc=Object.prototype.hasOwnProperty;var ee=(t,e)=>{for(var r in e)vn(t,r,{ge...}`).join(`
  * This package contains an URL to a domain with a suspicious extension at package/lib/index.cjs:1
        "use strict";var Kc=Object.create;var vn=Object.defineProperty;var Jc=Object.getOwnPropertyDescriptor;var Qc=Object.getOwnPropertyNames;var Yc=Object.getPrototypeOf,Zc=Object.prototype.hasOwnProperty;var ee=(t,e)=>{for(var r in e)vn(t,r,{ge...}`).join(`
 ...
```

To this:
```
shady-links: found 3 source code matches
  * This package contains an URL to a domain with a suspicious extension at package/lib/index.cjs:1
        "use strict";var Kc=Object.create;var vn=Object.defineProperty;var Jc=Object.getOwnPropertyDescriptor;var Qc=Object.getOwnPropertyNames;var Yc=Object.getPrototypeOf,Zc=Object.prototype.hasOwnProperty;var ee=(t,e)=>{for(var r in e)vn(t,r,{ge...}`).join(`
  * This package contains an URL to a domain with a suspicious extension at package/lib/index.global.js:14
        `),r=!1,a=!1,i;n.on("response",s=>{let{headers:o}=s;r=o["transfer-encoding"]==="chunked"&&!o["content-length"]}),n.on("socket",s=>{let o=()=>{if(r&&!a){let p=new Error("Premature close");p.code="ERR_STREAM_PREMATURE_CLOSE",e(p)}},c=p=>{a=(v...d Message:
  * This package contains an URL to a domain with a suspicious extension at package/lib/index.js:1
        var Ys=Object.defineProperty;var oe=(t,e)=>{for(var r in e)Ys(t,r,{get:e[r],enumerable:!0})};import{BigNumber as pp}from"bignumber.js";var bi={};oe(bi,{chains:()=>qe,envs:()=>it,schemas:()=>Ga});var ai={"1":{chainId:"1",explorer:"https://et...}`).join(`
```