### PR TITLE
Simplify local target checks

### DIFF
--- a/guarddog/cli.py
+++ b/guarddog/cli.py
@@ -4,6 +4,7 @@ CLI command that scans a package version for user-specified malware flags.
 Includes rules based on package registry metadata and source code analysis.
 """
 
+from functools import reduce
 import json as js
 import logging
 import os
@@ -20,7 +21,7 @@ from guarddog.ecosystems import ECOSYSTEM
 from guarddog.reporters.sarif import report_verify_sarif
 from guarddog.scanners import get_scanner
 from guarddog.scanners.scanner import PackageScanner
-from functools import reduce
+from guarddog.utils.archives import is_supported_archive
 
 EXIT_CODE_ISSUES_FOUND = 1
 
@@ -195,25 +196,10 @@ def is_local_target(identifier: str) -> bool:
     @param identifier:  The name/path of the package as passed to "guarddog ecosystem scan"
     @return:            Whether the identifier should be considered a local path
     """
-    if (
-        identifier.startswith("/")
-        or identifier.startswith("./")
-        or identifier.startswith("../")
-    ):
-        return True
-
-    if identifier == ".":
-        return True
-
-    # If this looks like an archive, consider it as a local target if the target exists on the local filesystem
-    if (
-        identifier.endswith(".tar.gz")
-        or identifier.endswith(".zip")
-        or identifier.endswith(".whl")
-    ):
-        return os.path.exists(identifier)
-
-    return False
+    return (
+        os.path.isdir(identifier)
+        or (os.path.isfile(identifier) and is_supported_archive(identifier))
+    )
 
 
 def _scan(

--- a/guarddog/cli.py
+++ b/guarddog/cli.py
@@ -191,17 +191,6 @@ def _verify(
     return return_value  # this is mostly for testing
 
 
-def is_local_target(identifier: str) -> bool:
-    """
-    @param identifier:  The name/path of the package as passed to "guarddog ecosystem scan"
-    @return:            Whether the identifier should be considered a local path
-    """
-    return (
-        os.path.isdir(identifier)
-        or (os.path.isfile(identifier) and is_supported_archive(identifier))
-    )
-
-
 def _scan(
     identifier,
     version,
@@ -226,20 +215,17 @@ def _scan(
         sys.exit(1)
 
     results = []
-    if is_local_target(identifier):
-        log.debug(
-            f"Considering that '{identifier}' is a local target, scanning filesystem"
-        )
-        if os.path.isdir(identifier):
-            log.debug(f"Considering that '{identifier}' as a local directory")
-            for package in os.listdir(identifier):
-                result = scanner.scan_local(f"{identifier}/{package}", rule_param)
-                result["package"] = package
-                results.append(result)
-        else:
-            result = scanner.scan_local(identifier, rule_param)
-            result["package"] = identifier
+    if os.path.isdir(identifier):
+        log.debug(f"Considering that '{identifier}' is a local directory")
+        for package in os.listdir(identifier):
+            result = scanner.scan_local(f"{identifier}/{package}", rule_param)
+            result["package"] = package
             results.append(result)
+    elif os.path.isfile(identifier):
+        log.debug(f"Considering that '{identifier}' is a local file")
+        result = scanner.scan_local(identifier, rule_param)
+        result["package"] = identifier
+        results.append(result)
     else:
         log.debug(f"Considering that '{identifier}' is a remote target")
         try:

--- a/guarddog/cli.py
+++ b/guarddog/cli.py
@@ -21,7 +21,6 @@ from guarddog.ecosystems import ECOSYSTEM
 from guarddog.reporters.sarif import report_verify_sarif
 from guarddog.scanners import get_scanner
 from guarddog.scanners.scanner import PackageScanner
-from guarddog.utils.archives import is_supported_archive
 
 EXIT_CODE_ISSUES_FOUND = 1
 

--- a/guarddog/scanners/pypi_package_scanner.py
+++ b/guarddog/scanners/pypi_package_scanner.py
@@ -4,6 +4,7 @@ import typing
 from guarddog.analyzer.analyzer import Analyzer
 from guarddog.ecosystems import ECOSYSTEM
 from guarddog.scanners.scanner import PackageScanner
+from guarddog.utils.archives import is_tar_archive, is_zip_archive
 from guarddog.utils.package_info import get_package_info
 
 
@@ -47,11 +48,11 @@ class PypiPackageScanner(PackageScanner):
 
         for file in files:
             # Store url to compressed package and appropriate file extension
-            if file["filename"].endswith(".tar.gz"):
+            if is_tar_archive(file["filename"]):
                 url = file["url"]
                 file_extension = ".tar.gz"
 
-            if any(file["filename"].endswith(ext) for ext in (".egg", ".whl", ".zip")):
+            if is_zip_archive(file["filename"]):
                 url = file["url"]
                 file_extension = ".zip"
 

--- a/guarddog/scanners/scanner.py
+++ b/guarddog/scanners/scanner.py
@@ -11,7 +11,7 @@ from concurrent.futures import ThreadPoolExecutor
 import requests
 
 from guarddog.analyzer.analyzer import Analyzer
-from guarddog.utils.archives import is_supported_archive, safe_extract
+from guarddog.utils.archives import safe_extract
 from guarddog.utils.config import PARALLELISM
 
 log = logging.getLogger("guarddog")
@@ -248,14 +248,12 @@ class PackageScanner(Scanner):
         results = None
         if os.path.isdir(path):
             results = self.analyzer.analyze_sourcecode(path, rules=rules)
-        elif (os.path.isfile(path) and is_supported_archive(path)):
+        elif os.path.isfile(path):
             with tempfile.TemporaryDirectory() as tempdir:
                 safe_extract(path, tempdir)
                 results = self.analyzer.analyze_sourcecode(tempdir, rules=rules)
         else:
-            raise Exception(
-                f"Path {path} is not a directory nor an archive supported by GuardDog."
-            )
+            raise Exception(f"Local scan target {path} is neither a directory nor a file.")
 
         callback(results)
 

--- a/guarddog/scanners/scanner.py
+++ b/guarddog/scanners/scanner.py
@@ -233,29 +233,33 @@ class PackageScanner(Scanner):
         Args:
             path (str): path to package
             rules (set, optional): Set of rule names to use. Defaults to all rules.
+            callback (typing.Callable[[dict], None], optional): Callback to apply to Analyzer output
 
         Raises:
             Exception: Analyzer exception
 
         Returns:
             dict: Analyzer output with rules to results mapping
-            rules: rules to apply
-            callback: callback to call for each result
         """
 
         if rules is not None:
             rules = set(rules)
 
+        results = None
         if os.path.isdir(path):
-            return self.analyzer.analyze_sourcecode(path, rules=rules)
+            results = self.analyzer.analyze_sourcecode(path, rules=rules)
         elif (os.path.isfile(path) and is_supported_archive(path)):
             with tempfile.TemporaryDirectory() as tempdir:
                 safe_extract(path, tempdir)
-                return self.analyzer.analyze_sourcecode(tempdir, rules=rules)
+                results = self.analyzer.analyze_sourcecode(tempdir, rules=rules)
         else:
             raise Exception(
                 f"Path {path} is not a directory nor an archive supported by GuardDog."
             )
+
+        callback(results)
+
+        return results
 
     @abstractmethod
     def download_and_get_package_info(

--- a/guarddog/utils/archives.py
+++ b/guarddog/utils/archives.py
@@ -7,20 +7,63 @@ import tarsafe  # type:ignore
 log = logging.getLogger("guarddog")
 
 
+def is_supported_archive(path: str) -> bool:
+    """
+    Decide whether a file contains a supported archive.
+
+    Args:
+        path (str): The local filesystem path to examine
+
+    Returns:
+        bool: Represents the decision reached for the file
+    """
+    return is_tar_archive(path) or is_zip_archive(path)
+
+
+def is_tar_archive(path: str) -> bool:
+    """
+    Decide whether a file contains a tar archive.
+
+    Args:
+        path (str): The local filesystem path to examine
+
+    Returns:
+        bool: Represents the decision reached for the file
+    """
+    return any(path.endswith(ext) for ext in [".tar.gz", ".tgz"])
+
+
+def is_zip_archive(path: str) -> bool:
+    """
+    Decide whether a file contains a zip, whl or egg archive.
+
+    Args:
+        path (str): The local filesystem path to examine
+
+    Returns:
+        bool: Represents the decision reached for the file
+    """
+    return any(path.endswith(ext) for ext in [".zip", ".whl", ".egg"])
+
+
 def safe_extract(source_archive: str, target_directory: str) -> None:
     """
     safe_extract safely extracts archives to a target directory.
 
-    This function does not clean up the original archive, and does not create the target directory if it does not exist.
+    This function does not clean up the original archive and does not
+    create the target directory if it does not exist.  It also assumes
+    the source archive argument is a path to a regular file on the
+    local filesystem.
 
     @param source_archive:      The archive to extract
     @param target_directory:    The directory where to extract the archive to
     @raise ValueError           If the archive type is unsupported
+
     """
     log.debug(f"Extracting archive {source_archive} to directory {target_directory}")
-    if source_archive.endswith('.tar.gz') or source_archive.endswith('.tgz'):
+    if is_tar_archive(source_archive):
         tarsafe.open(source_archive).extractall(target_directory)
-    elif source_archive.endswith('.zip') or source_archive.endswith('.whl'):
+    elif is_zip_archive(source_archive):
         with zipfile.ZipFile(source_archive, 'r') as zip:
             for file in zip.namelist():
                 # Note: zip.extract cleans up any malicious file name such as directory traversal attempts

--- a/guarddog/utils/archives.py
+++ b/guarddog/utils/archives.py
@@ -66,8 +66,9 @@ def safe_extract(source_archive: str, target_directory: str) -> None:
     elif is_zip_archive(source_archive):
         with zipfile.ZipFile(source_archive, 'r') as zip:
             for file in zip.namelist():
-                # Note: zip.extract cleans up any malicious file name such as directory traversal attempts
-                # This is not the case of zipfile.extractall
+                # Note: zip.extract cleans up any malicious file name
+                # such as directory traversal attempts This is not the
+                # case of zipfile.extractall
                 zip.extract(file, path=os.path.join(target_directory, file))
     else:
-        raise ValueError("unsupported archive extension: " + target_directory)
+        raise ValueError(f"unsupported archive extension: {source_archive}")

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -5,17 +5,39 @@ from guarddog.ecosystems import ECOSYSTEM
 
 
 def test_is_local_target():
-    assert guarddog.cli.is_local_target("/tmp/foo")
-    assert guarddog.cli.is_local_target("./foo")
-    assert guarddog.cli.is_local_target("../foo")
+    with unittest.mock.patch("os.path.isdir") as mock:
+        mock.return_value = True
+        assert guarddog.cli.is_local_target("/tmp/foo")
+
+    with unittest.mock.patch("os.path.isdir") as mock:
+        mock.return_value = False
+        assert not guarddog.cli.is_local_target("/tmp/foo")
+
+    with unittest.mock.patch("os.path.isdir") as mock:
+        mock.return_value = True
+        assert guarddog.cli.is_local_target("./foo")
+
+    with unittest.mock.patch("os.path.isdir") as mock:
+        mock.return_value = False
+        assert not guarddog.cli.is_local_target("./foo")
+
+    with unittest.mock.patch("os.path.isdir") as mock:
+        mock.return_value = True
+        assert guarddog.cli.is_local_target("../foo")
+
+    with unittest.mock.patch("os.path.isdir") as mock:
+        mock.return_value = False
+        assert not guarddog.cli.is_local_target("../foo")
+
     assert guarddog.cli.is_local_target(".")
+
     assert not guarddog.cli.is_local_target("foo")
 
-    with unittest.mock.patch("os.path.exists") as mock:
+    with unittest.mock.patch("os.path.isfile") as mock:
         mock.return_value = True
         assert guarddog.cli.is_local_target("foo.tar.gz")
 
-    with unittest.mock.patch("os.path.exists") as mock:
+    with unittest.mock.patch("os.path.isfile") as mock:
         mock.return_value = False
         assert not guarddog.cli.is_local_target("foo.tar.gz")
 

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -8,190 +8,22 @@ from guarddog.ecosystems import ECOSYSTEM
 
 class TestCli(unittest.TestCase):
 
-    def test_local_target(self):
-        # /tmp/foo is a directory
-        with mock.patch("os.path.isdir") as isdir:
-            isdir.return_value = True
-            with mock.patch("os.listdir") as listdir:
-                listdir.return_value = []
-                with self.assertLogs("guarddog", level="DEBUG") as cm:
-                    guarddog.cli._scan("/tmp/foo", "0.1.0", (), (), None, False, ECOSYSTEM.PYPI)
-                self.assertIn(
-                    "DEBUG:guarddog:Considering that '/tmp/foo' is a local directory",
-                    cm.output
-                )
-                self.assertNotIn(
-                    "DEBUG:guarddog:Considering that '/tmp/foo' is a local file",
-                    cm.output
-                )
-                self.assertNotIn(
-                    "DEBUG:guarddog:Considering that '/tmp/foo' is a remote target",
-                    cm.output
-                )
+    def test_local_directory(self):
+        """
+        Test that the CLI identifies local directories correctly
+        """
+        self._test_local_directory_template("/tmp/foo")
+        self._test_local_directory_template("./foo")
+        self._test_local_directory_template("../foo")
+        self._test_local_directory_template(".")
 
-        # /tmp/foo is neither a directory nor a file
-        with mock.patch("os.path.isdir") as isdir:
-            isdir.return_value = False
-            with mock.patch("os.path.isfile") as isfile:
-                isfile.return_value = False
-                with mock.patch.object(scanner.PackageScanner, 'scan_local', return_value={}) as _:
-                    with self.assertLogs("guarddog", level="DEBUG") as cm:
-                        guarddog.cli._scan("/tmp/foo", "0.1.0", (), (), None, False, ECOSYSTEM.PYPI)
-                    self.assertNotIn(
-                        "DEBUG:guarddog:Considering that '/tmp/foo' is a local directory",
-                        cm.output
-                    )
-                    self.assertNotIn(
-                        "DEBUG:guarddog:Considering that '/tmp/foo' is a local file",
-                        cm.output
-                    )
-                    self.assertIn(
-                        "DEBUG:guarddog:Considering that '/tmp/foo' is a remote target",
-                        cm.output
-                    )
-
-        # ./foo is a directory
-        with mock.patch("os.path.isdir") as isdir:
-            isdir.return_value = True
-            with mock.patch("os.listdir") as listdir:
-                listdir.return_value = []
-                with self.assertLogs("guarddog", level="DEBUG") as cm:
-                    guarddog.cli._scan("./foo", "0.1.0", (), (), None, False, ECOSYSTEM.PYPI)
-                self.assertIn(
-                    "DEBUG:guarddog:Considering that './foo' is a local directory",
-                    cm.output
-                )
-                self.assertNotIn(
-                    "DEBUG:guarddog:Considering that './foo' is a local file",
-                    cm.output
-                )
-                self.assertNotIn(
-                    "DEBUG:guarddog:Considering that './foo' is a remote target",
-                    cm.output
-                )
-
-        # ./foo is neither a directory nor a file
-        with mock.patch("os.path.isdir") as isdir:
-            isdir.return_value = False
-            with mock.patch("os.path.isfile") as isfile:
-                isfile.return_value = False
-                with mock.patch.object(scanner.PackageScanner, 'scan_local', return_value={}) as _:
-                    with self.assertLogs("guarddog", level="DEBUG") as cm:
-                        guarddog.cli._scan("./foo", "0.1.0", (), (), None, False, ECOSYSTEM.PYPI)
-                    self.assertNotIn(
-                        "DEBUG:guarddog:Considering that './foo' is a local directory",
-                        cm.output
-                    )
-                    self.assertNotIn(
-                        "DEBUG:guarddog:Considering that './foo' is a local file",
-                        cm.output
-                    )
-                    self.assertIn(
-                        "DEBUG:guarddog:Considering that './foo' is a remote target",
-                        cm.output
-                    )
-
-        # ../foo is a directory
-        with mock.patch("os.path.isdir") as isdir:
-            isdir.return_value = True
-            with mock.patch("os.listdir") as listdir:
-                listdir.return_value = []
-                with self.assertLogs("guarddog", level="DEBUG") as cm:
-                    guarddog.cli._scan("../foo", "0.1.0", (), (), None, False, ECOSYSTEM.PYPI)
-                self.assertIn(
-                    "DEBUG:guarddog:Considering that '../foo' is a local directory",
-                    cm.output
-                )
-                self.assertNotIn(
-                    "DEBUG:guarddog:Considering that '../foo' is a local file",
-                    cm.output
-                )
-                self.assertNotIn(
-                    "DEBUG:guarddog:Considering that '../foo' is a remote target",
-                    cm.output
-                )
-
-        # ../foo is neither a directory nor a file
-        with mock.patch("os.path.isdir") as isdir:
-            isdir.return_value = False
-            with mock.patch("os.path.isfile") as isfile:
-                isfile.return_value = False
-                with mock.patch.object(scanner.PackageScanner, 'scan_local', return_value={}) as _:
-                    with self.assertLogs("guarddog", level="DEBUG") as cm:
-                        guarddog.cli._scan("../foo", "0.1.0", (), (), None, False, ECOSYSTEM.PYPI)
-                    self.assertNotIn(
-                        "DEBUG:guarddog:Considering that '../foo' is a local directory",
-                        cm.output
-                    )
-                    self.assertNotIn(
-                        "DEBUG:guarddog:Considering that '../foo' is a local file",
-                        cm.output
-                    )
-                    self.assertIn(
-                        "DEBUG:guarddog:Considering that '../foo' is a remote target",
-                        cm.output
-                    )
-
-        # . is a directory
-        with mock.patch("os.listdir") as listdir:
-            listdir.return_value = []
-            with self.assertLogs("guarddog", level="DEBUG") as cm:
-                guarddog.cli._scan(".", "0.1.0", (), (), None, False, ECOSYSTEM.PYPI)
-            self.assertIn(
-                "DEBUG:guarddog:Considering that '.' is a local directory",
-                cm.output
-            )
-            self.assertNotIn(
-                "DEBUG:guarddog:Considering that '.' is a local file",
-                cm.output
-            )
-            self.assertNotIn(
-                "DEBUG:guarddog:Considering that '.' is a remote target",
-                cm.output
-            )
-
-        # foo is a file
-        with mock.patch("os.path.isdir") as isdir:
-            isdir.return_value = False
-            with mock.patch("os.path.isfile") as isfile:
-                isfile.return_value = True
-                with mock.patch.object(scanner.PackageScanner, 'scan_local', return_value={}) as _:
-                    with self.assertLogs("guarddog", level="DEBUG") as cm:
-                        guarddog.cli._scan("foo", "0.1.0", (), (), None, False, ECOSYSTEM.PYPI)
-                    self.assertNotIn(
-                        "DEBUG:guarddog:Considering that 'foo' is a local directory",
-                        cm.output
-                    )
-                    self.assertIn(
-                        "DEBUG:guarddog:Considering that 'foo' is a local file",
-                        cm.output
-                    )
-                    self.assertNotIn(
-                        "DEBUG:guarddog:Considering that 'foo' is a remote target",
-                        cm.output
-                    )
-
-        # foo is neither a directory nor a file
-        with mock.patch("os.path.isdir") as isdir:
-            isdir.return_value = False
-            with mock.patch("os.path.isfile") as isfile:
-                isfile.return_value = False
-                with mock.patch.object(scanner.PackageScanner, 'scan_local', return_value={}) as _:
-                    with self.assertLogs("guarddog", level="DEBUG") as cm:
-                        guarddog.cli._scan("foo", "0.1.0", (), (), None, False, ECOSYSTEM.PYPI)
-                    self.assertNotIn(
-                        "DEBUG:guarddog:Considering that 'foo' is a local directory",
-                        cm.output
-                    )
-                    self.assertNotIn(
-                        "DEBUG:guarddog:Considering that 'foo' is a local file",
-                        cm.output
-                    )
-                    self.assertIn(
-                        "DEBUG:guarddog:Considering that 'foo' is a remote target",
-                        cm.output
-                    )
-
+    def test_local_file(self):
+        """
+        Test that the CLI identifies local files correctly
+        """
+        self._test_local_file_template("/tmp/foo")
+        self._test_local_file_template("./foo")
+        self._test_local_file_template("../foo")
 
     def test_get_rule_param_include(self):
         """
@@ -216,6 +48,91 @@ class TestCli(unittest.TestCase):
         """
         rules = guarddog.cli._get_rule_param((), (), ECOSYSTEM.PYPI)
         assert rules is None
+
+    def _test_local_directory_template(self, directory: str):
+        # `directory` is a directory
+        with mock.patch("os.path.isdir") as isdir:
+            isdir.return_value = True
+            with mock.patch("os.listdir") as listdir:
+                listdir.return_value = []
+                with self.assertLogs("guarddog", level="DEBUG") as cm:
+                    guarddog.cli._scan(directory, "0.1.0", (), (), None, False, ECOSYSTEM.PYPI)
+                self.assertIn(
+                    f"DEBUG:guarddog:Considering that '{directory}' is a local directory",
+                    cm.output
+                )
+                self.assertNotIn(
+                    f"DEBUG:guarddog:Considering that '{directory}' is a local file",
+                    cm.output
+                )
+                self.assertNotIn(
+                    f"DEBUG:guarddog:Considering that '{directory}' is a remote target",
+                    cm.output
+                )
+
+        # `directory` is neither a directory nor a file
+        with mock.patch("os.path.isdir") as isdir:
+            isdir.return_value = False
+            with mock.patch("os.path.isfile") as isfile:
+                isfile.return_value = False
+                with mock.patch.object(scanner.PackageScanner, 'scan_local', return_value={}) as _:
+                    with self.assertLogs("guarddog", level="DEBUG") as cm:
+                        guarddog.cli._scan(directory, "0.1.0", (), (), None, False, ECOSYSTEM.PYPI)
+                    self.assertNotIn(
+                        f"DEBUG:guarddog:Considering that '{directory}' is a local directory",
+                        cm.output
+                    )
+                    self.assertNotIn(
+                        f"DEBUG:guarddog:Considering that '{directory}' is a local file",
+                        cm.output
+                    )
+                    self.assertIn(
+                        f"DEBUG:guarddog:Considering that '{directory}' is a remote target",
+                        cm.output
+                    )
+
+    def _test_local_file_template(self, filename: str):
+        # `filename` is a file
+        with mock.patch("os.path.isdir") as isdir:
+            isdir.return_value = False
+            with mock.patch("os.path.isfile") as isfile:
+                isfile.return_value = True
+                with mock.patch.object(scanner.PackageScanner, 'scan_local', return_value={}) as _:
+                    with self.assertLogs("guarddog", level="DEBUG") as cm:
+                        guarddog.cli._scan(filename, "0.1.0", (), (), None, False, ECOSYSTEM.PYPI)
+                    self.assertNotIn(
+                        f"DEBUG:guarddog:Considering that '{filename}' is a local directory",
+                        cm.output
+                    )
+                    self.assertIn(
+                        f"DEBUG:guarddog:Considering that '{filename}' is a local file",
+                        cm.output
+                    )
+                    self.assertNotIn(
+                        f"DEBUG:guarddog:Considering that '{filename}' is a remote target",
+                        cm.output
+                    )
+
+        # `filename` is neither a directory nor a file
+        with mock.patch("os.path.isdir") as isdir:
+            isdir.return_value = False
+            with mock.patch("os.path.isfile") as isfile:
+                isfile.return_value = False
+                with mock.patch.object(scanner.PackageScanner, 'scan_local', return_value={}) as _:
+                    with self.assertLogs("guarddog", level="DEBUG") as cm:
+                        guarddog.cli._scan(filename, "0.1.0", (), (), None, False, ECOSYSTEM.PYPI)
+                    self.assertNotIn(
+                        f"DEBUG:guarddog:Considering that '{filename}' is a local directory",
+                        cm.output
+                    )
+                    self.assertNotIn(
+                        f"DEBUG:guarddog:Considering that '{filename}' is a local file",
+                        cm.output
+                    )
+                    self.assertIn(
+                        f"DEBUG:guarddog:Considering that '{filename}' is a remote target",
+                        cm.output
+                    )
 
 
 if __name__ == "__main__":

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -1,67 +1,222 @@
-import unittest.mock
+import unittest
+import unittest.mock as mock
 
 import guarddog.cli
+import guarddog.scanners.scanner as scanner
 from guarddog.ecosystems import ECOSYSTEM
 
 
-def test_is_local_target():
-    with unittest.mock.patch("os.path.isdir") as mock:
-        mock.return_value = True
-        assert guarddog.cli.is_local_target("/tmp/foo")
+class TestCli(unittest.TestCase):
 
-    with unittest.mock.patch("os.path.isdir") as mock:
-        mock.return_value = False
-        assert not guarddog.cli.is_local_target("/tmp/foo")
+    def test_local_target(self):
+        # /tmp/foo is a directory
+        with mock.patch("os.path.isdir") as isdir:
+            isdir.return_value = True
+            with mock.patch("os.listdir") as listdir:
+                listdir.return_value = []
+                with self.assertLogs("guarddog", level="DEBUG") as cm:
+                    guarddog.cli._scan("/tmp/foo", "0.1.0", (), (), None, False, ECOSYSTEM.PYPI)
+                self.assertIn(
+                    "DEBUG:guarddog:Considering that '/tmp/foo' is a local directory",
+                    cm.output
+                )
+                self.assertNotIn(
+                    "DEBUG:guarddog:Considering that '/tmp/foo' is a local file",
+                    cm.output
+                )
+                self.assertNotIn(
+                    "DEBUG:guarddog:Considering that '/tmp/foo' is a remote target",
+                    cm.output
+                )
 
-    with unittest.mock.patch("os.path.isdir") as mock:
-        mock.return_value = True
-        assert guarddog.cli.is_local_target("./foo")
+        # /tmp/foo is neither a directory nor a file
+        with mock.patch("os.path.isdir") as isdir:
+            isdir.return_value = False
+            with mock.patch("os.path.isfile") as isfile:
+                isfile.return_value = False
+                with mock.patch.object(scanner.PackageScanner, 'scan_local', return_value={}) as _:
+                    with self.assertLogs("guarddog", level="DEBUG") as cm:
+                        guarddog.cli._scan("/tmp/foo", "0.1.0", (), (), None, False, ECOSYSTEM.PYPI)
+                    self.assertNotIn(
+                        "DEBUG:guarddog:Considering that '/tmp/foo' is a local directory",
+                        cm.output
+                    )
+                    self.assertNotIn(
+                        "DEBUG:guarddog:Considering that '/tmp/foo' is a local file",
+                        cm.output
+                    )
+                    self.assertIn(
+                        "DEBUG:guarddog:Considering that '/tmp/foo' is a remote target",
+                        cm.output
+                    )
 
-    with unittest.mock.patch("os.path.isdir") as mock:
-        mock.return_value = False
-        assert not guarddog.cli.is_local_target("./foo")
+        # ./foo is a directory
+        with mock.patch("os.path.isdir") as isdir:
+            isdir.return_value = True
+            with mock.patch("os.listdir") as listdir:
+                listdir.return_value = []
+                with self.assertLogs("guarddog", level="DEBUG") as cm:
+                    guarddog.cli._scan("./foo", "0.1.0", (), (), None, False, ECOSYSTEM.PYPI)
+                self.assertIn(
+                    "DEBUG:guarddog:Considering that './foo' is a local directory",
+                    cm.output
+                )
+                self.assertNotIn(
+                    "DEBUG:guarddog:Considering that './foo' is a local file",
+                    cm.output
+                )
+                self.assertNotIn(
+                    "DEBUG:guarddog:Considering that './foo' is a remote target",
+                    cm.output
+                )
 
-    with unittest.mock.patch("os.path.isdir") as mock:
-        mock.return_value = True
-        assert guarddog.cli.is_local_target("../foo")
+        # ./foo is neither a directory nor a file
+        with mock.patch("os.path.isdir") as isdir:
+            isdir.return_value = False
+            with mock.patch("os.path.isfile") as isfile:
+                isfile.return_value = False
+                with mock.patch.object(scanner.PackageScanner, 'scan_local', return_value={}) as _:
+                    with self.assertLogs("guarddog", level="DEBUG") as cm:
+                        guarddog.cli._scan("./foo", "0.1.0", (), (), None, False, ECOSYSTEM.PYPI)
+                    self.assertNotIn(
+                        "DEBUG:guarddog:Considering that './foo' is a local directory",
+                        cm.output
+                    )
+                    self.assertNotIn(
+                        "DEBUG:guarddog:Considering that './foo' is a local file",
+                        cm.output
+                    )
+                    self.assertIn(
+                        "DEBUG:guarddog:Considering that './foo' is a remote target",
+                        cm.output
+                    )
 
-    with unittest.mock.patch("os.path.isdir") as mock:
-        mock.return_value = False
-        assert not guarddog.cli.is_local_target("../foo")
+        # ../foo is a directory
+        with mock.patch("os.path.isdir") as isdir:
+            isdir.return_value = True
+            with mock.patch("os.listdir") as listdir:
+                listdir.return_value = []
+                with self.assertLogs("guarddog", level="DEBUG") as cm:
+                    guarddog.cli._scan("../foo", "0.1.0", (), (), None, False, ECOSYSTEM.PYPI)
+                self.assertIn(
+                    "DEBUG:guarddog:Considering that '../foo' is a local directory",
+                    cm.output
+                )
+                self.assertNotIn(
+                    "DEBUG:guarddog:Considering that '../foo' is a local file",
+                    cm.output
+                )
+                self.assertNotIn(
+                    "DEBUG:guarddog:Considering that '../foo' is a remote target",
+                    cm.output
+                )
 
-    assert guarddog.cli.is_local_target(".")
+        # ../foo is neither a directory nor a file
+        with mock.patch("os.path.isdir") as isdir:
+            isdir.return_value = False
+            with mock.patch("os.path.isfile") as isfile:
+                isfile.return_value = False
+                with mock.patch.object(scanner.PackageScanner, 'scan_local', return_value={}) as _:
+                    with self.assertLogs("guarddog", level="DEBUG") as cm:
+                        guarddog.cli._scan("../foo", "0.1.0", (), (), None, False, ECOSYSTEM.PYPI)
+                    self.assertNotIn(
+                        "DEBUG:guarddog:Considering that '../foo' is a local directory",
+                        cm.output
+                    )
+                    self.assertNotIn(
+                        "DEBUG:guarddog:Considering that '../foo' is a local file",
+                        cm.output
+                    )
+                    self.assertIn(
+                        "DEBUG:guarddog:Considering that '../foo' is a remote target",
+                        cm.output
+                    )
 
-    assert not guarddog.cli.is_local_target("foo")
+        # . is a directory
+        with mock.patch("os.listdir") as listdir:
+            listdir.return_value = []
+            with self.assertLogs("guarddog", level="DEBUG") as cm:
+                guarddog.cli._scan(".", "0.1.0", (), (), None, False, ECOSYSTEM.PYPI)
+            self.assertIn(
+                "DEBUG:guarddog:Considering that '.' is a local directory",
+                cm.output
+            )
+            self.assertNotIn(
+                "DEBUG:guarddog:Considering that '.' is a local file",
+                cm.output
+            )
+            self.assertNotIn(
+                "DEBUG:guarddog:Considering that '.' is a remote target",
+                cm.output
+            )
 
-    with unittest.mock.patch("os.path.isfile") as mock:
-        mock.return_value = True
-        assert guarddog.cli.is_local_target("foo.tar.gz")
+        # foo is a file
+        with mock.patch("os.path.isdir") as isdir:
+            isdir.return_value = False
+            with mock.patch("os.path.isfile") as isfile:
+                isfile.return_value = True
+                with mock.patch.object(scanner.PackageScanner, 'scan_local', return_value={}) as _:
+                    with self.assertLogs("guarddog", level="DEBUG") as cm:
+                        guarddog.cli._scan("foo", "0.1.0", (), (), None, False, ECOSYSTEM.PYPI)
+                    self.assertNotIn(
+                        "DEBUG:guarddog:Considering that 'foo' is a local directory",
+                        cm.output
+                    )
+                    self.assertIn(
+                        "DEBUG:guarddog:Considering that 'foo' is a local file",
+                        cm.output
+                    )
+                    self.assertNotIn(
+                        "DEBUG:guarddog:Considering that 'foo' is a remote target",
+                        cm.output
+                    )
 
-    with unittest.mock.patch("os.path.isfile") as mock:
-        mock.return_value = False
-        assert not guarddog.cli.is_local_target("foo.tar.gz")
+        # foo is neither a directory nor a file
+        with mock.patch("os.path.isdir") as isdir:
+            isdir.return_value = False
+            with mock.patch("os.path.isfile") as isfile:
+                isfile.return_value = False
+                with mock.patch.object(scanner.PackageScanner, 'scan_local', return_value={}) as _:
+                    with self.assertLogs("guarddog", level="DEBUG") as cm:
+                        guarddog.cli._scan("foo", "0.1.0", (), (), None, False, ECOSYSTEM.PYPI)
+                    self.assertNotIn(
+                        "DEBUG:guarddog:Considering that 'foo' is a local directory",
+                        cm.output
+                    )
+                    self.assertNotIn(
+                        "DEBUG:guarddog:Considering that 'foo' is a local file",
+                        cm.output
+                    )
+                    self.assertIn(
+                        "DEBUG:guarddog:Considering that 'foo' is a remote target",
+                        cm.output
+                    )
 
 
-def test_get_rule_param_include():
-    """
-    Test the parsing function returns the included parameter
-    """
-    rules = guarddog.cli._get_rule_param(("shady-links",), (), ECOSYSTEM.NPM)
-    assert rules
-    assert len(rules) == 1
+    def test_get_rule_param_include(self):
+        """
+        Test the parsing function returns the included parameter
+        """
+        rules = guarddog.cli._get_rule_param(("shady-links",), (), ECOSYSTEM.NPM)
+        assert rules
+        assert len(rules) == 1
 
-def test_get_rule_param_exclude():
-    """
-    Test the parsing function returns a list without the excluded parameter
-    """
-    rules = guarddog.cli._get_rule_param((), ("shady-links",), ECOSYSTEM.PYPI)
-    assert rules
-    assert len(rules) != 1
-    assert "shady-links" not in rules
+    def test_get_rule_param_exclude(self):
+        """
+        Test the parsing function returns a list without the excluded parameter
+        """
+        rules = guarddog.cli._get_rule_param((), ("shady-links",), ECOSYSTEM.PYPI)
+        assert rules
+        assert len(rules) != 1
+        assert "shady-links" not in rules
 
-def test_get_rule_param_empty():
-    """
-    Test the parsing function returns None when no rules are provided
-    """
-    rules = guarddog.cli._get_rule_param((), (), ECOSYSTEM.PYPI)
-    assert rules is None
+    def test_get_rule_param_empty(self):
+        """
+        Test the parsing function returns None when no rules are provided
+        """
+        rules = guarddog.cli._get_rule_param((), (), ECOSYSTEM.PYPI)
+        assert rules is None
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR makes three principal changes:

1. It simplifies the conditions under which Guarddog will decide to perform a local scan: whenever the target is a directory or a regular file in the local filesystem.  It also eliminates as much as possible duplicate checks related to local targets

2. It adds functions in `guarddog/utils/archives.py` for checking whether a file extension is for a supported archive format and uses them pervasively

3. Closes #411