### PR TITLE
Eliminate Package class

### DIFF
--- a/guarddog/cli.py
+++ b/guarddog/cli.py
@@ -10,7 +10,7 @@ import logging
 import os
 import sys
 import tempfile
-from typing import Optional, cast
+from typing import Optional
 
 import click
 from prettytable import PrettyTable
@@ -20,8 +20,7 @@ from guarddog.analyzer.metadata import get_metadata_detectors
 from guarddog.analyzer.sourcecode import get_sourcecode_rules
 from guarddog.ecosystems import ECOSYSTEM
 from guarddog.reporters.sarif import report_verify_sarif
-from guarddog.scanners import get_scanner
-from guarddog.scanners.scanner import PackageScanner
+from guarddog.scanners import get_package_scanner, get_project_scanner
 from guarddog.utils.archives import safe_extract
 
 EXIT_CODE_ISSUES_FOUND = 1
@@ -158,7 +157,7 @@ def _verify(
     """
     return_value = None
     rule_param = _get_rule_param(rules, exclude_rules, ecosystem)
-    scanner = get_scanner(ecosystem, True)
+    scanner = get_project_scanner(ecosystem)
     if scanner is None:
         sys.stderr.write(f"Command verify is not supported for ecosystem {ecosystem}")
         exit(1)
@@ -210,7 +209,7 @@ def _scan(
     """
 
     rule_param = _get_rule_param(rules, exclude_rules, ecosystem)
-    scanner = cast(Optional[PackageScanner], get_scanner(ecosystem, False))
+    scanner = get_package_scanner(ecosystem)
     if scanner is None:
         sys.stderr.write(f"Command scan is not supported for ecosystem {ecosystem}")
         sys.exit(1)

--- a/guarddog/scanners/__init__.py
+++ b/guarddog/scanners/__init__.py
@@ -6,22 +6,45 @@ from .pypi_package_scanner import PypiPackageScanner
 from .pypi_project_scanner import PypiRequirementsScanner
 from .go_package_scanner import GoModuleScanner
 from .go_project_scanner import GoDependenciesScanner
-from .scanner import Scanner
+from .scanner import PackageScanner, ProjectScanner
 from ..ecosystems import ECOSYSTEM
 
 
-def get_scanner(ecosystem: ECOSYSTEM, project: bool) -> Optional[Scanner]:
-    match (ecosystem, project):
-        case (ECOSYSTEM.PYPI, False):
+def get_package_scanner(ecosystem: ECOSYSTEM) -> Optional[PackageScanner]:
+    """
+    TODO
+
+    Args:
+        ecosystem (ECOSYSTEM): TODO
+
+    Returns:
+        Optional[PackageScanner]: TODO
+    """
+    match ecosystem:
+        case ECOSYSTEM.PYPI:
             return PypiPackageScanner()
-        case (ECOSYSTEM.PYPI, True):
-            return PypiRequirementsScanner()
-        case (ECOSYSTEM.NPM, False):
+        case ECOSYSTEM.NPM:
             return NPMPackageScanner()
-        case (ECOSYSTEM.NPM, True):
-            return NPMRequirementsScanner()
-        case (ECOSYSTEM.GO, False):
+        case ECOSYSTEM.GO:
             return GoModuleScanner()
-        case (ECOSYSTEM.GO, True):
+    return None
+
+
+def get_project_scanner(ecosystem: ECOSYSTEM) -> Optional[ProjectScanner]:
+    """
+    TODO
+
+    Args:
+        ecosystem (ECOSYSTEM): TODO
+
+    Returns:
+        Optional[ProjectScanner]: TODO
+    """
+    match ecosystem:
+        case ECOSYSTEM.PYPI:
+            return PypiRequirementsScanner()
+        case ECOSYSTEM.NPM:
+            return NPMRequirementsScanner()
+        case ECOSYSTEM.GO:
             return GoDependenciesScanner()
     return None

--- a/guarddog/scanners/__init__.py
+++ b/guarddog/scanners/__init__.py
@@ -12,13 +12,15 @@ from ..ecosystems import ECOSYSTEM
 
 def get_package_scanner(ecosystem: ECOSYSTEM) -> Optional[PackageScanner]:
     """
-    TODO
+    Return a `PackageScanner` for the given ecosystem or `None` if it
+    is not yet supported.
 
     Args:
-        ecosystem (ECOSYSTEM): TODO
+        ecosystem (ECOSYSTEM): The ecosystem of the desired scanner
 
     Returns:
-        Optional[PackageScanner]: TODO
+        Optional[PackageScanner]: The result of the scanner request
+
     """
     match ecosystem:
         case ECOSYSTEM.PYPI:
@@ -32,13 +34,15 @@ def get_package_scanner(ecosystem: ECOSYSTEM) -> Optional[PackageScanner]:
 
 def get_project_scanner(ecosystem: ECOSYSTEM) -> Optional[ProjectScanner]:
     """
-    TODO
+    Return a `ProjectScanner` for the given ecosystem or `None` if
+    it is not yet supported.
 
     Args:
-        ecosystem (ECOSYSTEM): TODO
+        ecosystem (ECOSYSTEM): The ecosystem of the desired scanner
 
     Returns:
-        Optional[ProjectScanner]: TODO
+        Optional[ProjectScanner]: The result of the scanner request
+
     """
     match ecosystem:
         case ECOSYSTEM.PYPI:

--- a/guarddog/scanners/scanner.py
+++ b/guarddog/scanners/scanner.py
@@ -21,18 +21,7 @@ def noop(arg: typing.Any) -> None:
     pass
 
 
-class Scanner:
-    def __init__(self) -> None:
-        pass
-
-    @abstractmethod
-    def scan_local(
-        self, path, rules=None, callback: typing.Callable[[dict], None] = noop
-    ):
-        pass
-
-
-class ProjectScanner(Scanner):
+class ProjectScanner:
     def __init__(self, package_scanner):
         super().__init__()
         self.package_scanner = package_scanner
@@ -212,7 +201,7 @@ class ProjectScanner(Scanner):
         pass
 
 
-class PackageScanner(Scanner):
+class PackageScanner:
     """
     Scans package for attack vectors based on source code and metadata rules
 


### PR DESCRIPTION
This PR proposes to eliminate the `Package` class, which superclasses `PackageScanner` and `ProjectScanner`.

Reasons to do this:

1. There is no context in which a `PackageScanner` and a `ProjectScanner` can be used interchangeably without a great deal of difficulty.  These classes have only one common method, `scan_local()`, that expect different kinds (as opposed to types) of arguments: a path to a local package directory or archive for `PackageScanner` versus a path to a `requirements.txt` file for `ProjectScanner`

2. It seems the only purpose of `Package` is to give `scanner.get_scanner()` a definite, non-union return type.  However, we end up paying elsewhere for this simplicity, namely via the explicit cast in `cli._scan()` needed only to satisfy the type checker, so it's not clear we gain anything from it.  This PR splits `get_scanner()` into two functions to eliminate the cast