### PR TITLE
Standardize local scanning behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,11 @@ guarddog pypi scan requests --rules exec-base64 --rules code-execution
 # Scan the 'requests' package using all rules but one
 guarddog pypi scan requests --exclude-rules exec-base64
 
-# Scan a local package
+# Scan a local package archive
 guarddog pypi scan /tmp/triage.tar.gz
 
-# Scan a local directory, the packages need to be located in the root directory
-# For instance you have several pypi packages in ./samples/ like:
-# ./samples/package1.tar.gz ./samples/package2.zip ./samples/package3.whl
-# FYI if a file not supported by guarddog is found you will get an error
-# Here is the command to scan a directory:
-guarddog pypi scan ./samples/
+# Scan a local package directory
+guarddog pypi scan /tmp/requests-2.28.1/
 
 # Scan every package referenced in a requirements.txt file of a local folder
 guarddog pypi verify workspace/guarddog/requirements.txt

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ guarddog pypi scan requests --exclude-rules exec-base64
 guarddog pypi scan /tmp/triage.tar.gz
 
 # Scan a local package directory
-guarddog pypi scan /tmp/requests-2.28.1/
+guarddog pypi scan /tmp/triage/
 
 # Scan every package referenced in a requirements.txt file of a local folder
 guarddog pypi verify workspace/guarddog/requirements.txt

--- a/guarddog/cli.py
+++ b/guarddog/cli.py
@@ -213,40 +213,28 @@ def _scan(
         sys.stderr.write(f"Command scan is not supported for ecosystem {ecosystem}")
         sys.exit(1)
 
-    results = []
+    result = {"package": identifier}
     if os.path.isdir(identifier):
         log.debug(f"Considering that '{identifier}' is a local directory")
-        result = scanner.scan_local(identifier, rule_param)
-        result["package"] = identifier
-        results.append(result)
+        result |= scanner.scan_local(identifier, rule_param)
     elif os.path.isfile(identifier):
         log.debug(f"Considering that '{identifier}' is a local file")
-        result = scanner.scan_local(identifier, rule_param)
-        result["package"] = identifier
-        results.append(result)
+        result |= scanner.scan_local(identifier, rule_param)
     else:
         log.debug(f"Considering that '{identifier}' is a remote target")
         try:
-            result = scanner.scan_remote(identifier, version, rule_param)
-            result["package"] = identifier
-            results.append(result)
+            result |= scanner.scan_remote(identifier, version, rule_param)
         except Exception as e:
             sys.stderr.write(f"\nError '{e}' occurred while scanning remote package.")
             sys.exit(1)
 
     if output_format == "json":
-        if len(results) == 1:
-            # return only a json like {}
-            print(js.dumps(results[0]))
-        else:
-            # Return a list of result like [{},{}]
-            print(js.dumps(results))
+        print(js.dumps(result))
     else:
-        for result in results:
-            print_scan_results(result, result["package"])
+        print_scan_results(result, result["package"])
 
     if exit_non_zero_on_finding:
-        exit_with_status_code(results)
+        exit_with_status_code([result])
 
 
 def _list_rules(ecosystem: ECOSYSTEM):

--- a/guarddog/cli.py
+++ b/guarddog/cli.py
@@ -216,21 +216,21 @@ def _scan(
         sys.exit(1)
 
     result = {"package": identifier}
-    if os.path.isdir(identifier):
-        log.debug(f"Considering that '{identifier}' is a local directory")
-        result |= scanner.scan_local(identifier, rule_param)
-    elif os.path.isfile(identifier):
-        log.debug(f"Considering that '{identifier}' is a local archive file")
-        with tempfile.TemporaryDirectory() as tempdir:
-            safe_extract(identifier, tempdir)
-            result |= scanner.scan_local(tempdir, rule_param)
-    else:
-        log.debug(f"Considering that '{identifier}' is a remote target")
-        try:
+    try:
+        if os.path.isdir(identifier):
+            log.debug(f"Considering that '{identifier}' is a local directory")
+            result |= scanner.scan_local(identifier, rule_param)
+        elif os.path.isfile(identifier):
+            log.debug(f"Considering that '{identifier}' is a local archive file")
+            with tempfile.TemporaryDirectory() as tempdir:
+                safe_extract(identifier, tempdir)
+                result |= scanner.scan_local(tempdir, rule_param)
+        else:
+            log.debug(f"Considering that '{identifier}' is a remote target")
             result |= scanner.scan_remote(identifier, version, rule_param)
-        except Exception as e:
-            sys.stderr.write(f"\nError '{e}' occurred while scanning remote package.")
-            sys.exit(1)
+    except Exception as e:
+        sys.stderr.write(f"Error occurred while scanning target {identifier}: '{e}'\n")
+        sys.exit(1)
 
     if output_format == "json":
         print(js.dumps(result))

--- a/guarddog/cli.py
+++ b/guarddog/cli.py
@@ -216,10 +216,9 @@ def _scan(
     results = []
     if os.path.isdir(identifier):
         log.debug(f"Considering that '{identifier}' is a local directory")
-        for package in os.listdir(identifier):
-            result = scanner.scan_local(f"{identifier}/{package}", rule_param)
-            result["package"] = package
-            results.append(result)
+        result = scanner.scan_local(identifier, rule_param)
+        result["package"] = identifier
+        results.append(result)
     elif os.path.isfile(identifier):
         log.debug(f"Considering that '{identifier}' is a local file")
         result = scanner.scan_local(identifier, rule_param)

--- a/guarddog/scanners/scanner.py
+++ b/guarddog/scanners/scanner.py
@@ -231,7 +231,7 @@ class PackageScanner(Scanner):
         Scans local package
 
         Args:
-            path (str): path to package
+            path (str): Path to the directory containing the package to analyze
             rules (set, optional): Set of rule names to use. Defaults to all rules.
             callback (typing.Callable[[dict], None], optional): Callback to apply to Analyzer output
 
@@ -245,16 +245,7 @@ class PackageScanner(Scanner):
         if rules is not None:
             rules = set(rules)
 
-        results = None
-        if os.path.isdir(path):
-            results = self.analyzer.analyze_sourcecode(path, rules=rules)
-        elif os.path.isfile(path):
-            with tempfile.TemporaryDirectory() as tempdir:
-                safe_extract(path, tempdir)
-                results = self.analyzer.analyze_sourcecode(tempdir, rules=rules)
-        else:
-            raise Exception(f"Local scan target {path} is neither a directory nor a file.")
-
+        results = self.analyzer.analyze_sourcecode(path, rules=rules)
         callback(results)
 
         return results

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -107,9 +107,8 @@ class TestCli(unittest.TestCase):
                             try:
                                 with self.assertLogs("guarddog", level="DEBUG") as cm:
                                     guarddog.cli._scan(filename, "0.1.0", (), (), None, False, ECOSYSTEM.PYPI)
-                            # Since is_tar_archive and is_zip_archive
-                            # have been patched accordingly, we always
-                            # end up here
+                            # Since is_tar_archive and is_zip_archive have been
+                            # patched accordingly, we always end up here
                             except ValueError:
                                 self.assertNotIn(
                                     f"DEBUG:guarddog:Considering that '{filename}' is a local directory",

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -109,7 +109,7 @@ class TestCli(unittest.TestCase):
                                     guarddog.cli._scan(filename, "0.1.0", (), (), None, False, ECOSYSTEM.PYPI)
                             # Since is_tar_archive and is_zip_archive have been
                             # patched accordingly, we always end up here
-                            except ValueError:
+                            except SystemExit:
                                 self.assertNotIn(
                                     f"DEBUG:guarddog:Considering that '{filename}' is a local directory",
                                     cm.output


### PR DESCRIPTION
This PR changes GuardDog's behavior in the case of a local directory scan so that it expects the directory to contain a package.  This makes it so that a local scan always expects a (possibly zipped) package directory as its target.

```shell
$ guarddog pypi scan ~/Downloads/requests-2.32.3.tar.gz
Found 0 potentially malicious indicators scanning ~/Downloads/requests-2.32.3.tar.gz

$ tar -xf ~/Downloads/requests-2.32.3.tar.gz -C ~/Downloads
$ guarddog pypi scan ~/Downloads/requests-2.32.3
Found 0 potentially malicious indicators scanning ~/Downloads/requests-2.32.3

$
```

Closes #425 