### PR TITLE
Removing npm-install-script False Positives 

### DIFF
--- a/guarddog/analyzer/sourcecode/npm-install-script.yml
+++ b/guarddog/analyzer/sourcecode/npm-install-script.yml
@@ -10,6 +10,17 @@ rules:
       # (typically when a dependency is a git repository, see https://github.com/npm/cli/issues/6031#issuecomment-1449119423)
       # however this happens pretty rarely so reporting every package with a "prepare" script would be too noisy;
       # see https://github.com/DataDog/guarddog/issues/308
+      - pattern-not: |
+            "...": "npx only-allow pnpm"
+      - pattern-not: |
+          "...": ""
+      - pattern-not: |
+          "...": "patch-package"
+      - pattern-not: |
+          "...": "husky"
+      - pattern-not: |
+          "preinstall": "echo \"preinstall script\""
+
       - pattern-either:
           - pattern: |
               "preinstall": "..."

--- a/tests/analyzer/sourcecode/npm-install-script.json
+++ b/tests/analyzer/sourcecode/npm-install-script.json
@@ -5,8 +5,18 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    // ruleid: npm-install-script
-    "postinstall": "echo Running malicious code"
+    "dummy_child1": {
+       // ruleid: npm-install-script
+      "postinstall": "echo Running malicious code",
+    },
+    "dummy_child2": {
+       // ok: npm-install-script
+      "postinstall": "npx only-allow pnpm",
+    },
+    "dummy_child3": {
+       // ok: npm-install-script
+      "preinstall": "husky",
+    },
   },
   "author": "",
   "license": "ISC"


### PR DESCRIPTION
Removing the following patterns in order to reduce the amount of False Positives of the rule