### PR TITLE
Expand allowed tar archive compression algorithms

### DIFF
--- a/guarddog/utils/archives.py
+++ b/guarddog/utils/archives.py
@@ -1,7 +1,8 @@
 import logging
 import os
-import zipfile
 import stat
+import zipfile
+
 import tarsafe  # type:ignore
 
 log = logging.getLogger("guarddog")
@@ -9,41 +10,23 @@ log = logging.getLogger("guarddog")
 
 def is_supported_archive(path: str) -> bool:
     """
-    Decide whether a file contains a supported archive.
+    Decide whether a file contains a supported archive based on its
+    file extension.
 
     Args:
         path (str): The local filesystem path to examine
 
     Returns:
         bool: Represents the decision reached for the file
+
     """
+    def is_tar_archive(path: str) -> bool:
+        return any(path.endswith(ext) for ext in [".tar.gz", ".tgz"])
+
+    def is_zip_archive(path: str) -> bool:
+        return any(path.endswith(ext) for ext in [".zip", ".whl", ".egg"])
+
     return is_tar_archive(path) or is_zip_archive(path)
-
-
-def is_tar_archive(path: str) -> bool:
-    """
-    Decide whether a file contains a tar archive.
-
-    Args:
-        path (str): The local filesystem path to examine
-
-    Returns:
-        bool: Represents the decision reached for the file
-    """
-    return any(path.endswith(ext) for ext in [".tar.gz", ".tgz"])
-
-
-def is_zip_archive(path: str) -> bool:
-    """
-    Decide whether a file contains a zip, whl or egg archive.
-
-    Args:
-        path (str): The local filesystem path to examine
-
-    Returns:
-        bool: Represents the decision reached for the file
-    """
-    return any(path.endswith(ext) for ext in [".zip", ".whl", ".egg"])
 
 
 def safe_extract(source_archive: str, target_directory: str) -> None:
@@ -61,7 +44,7 @@ def safe_extract(source_archive: str, target_directory: str) -> None:
 
     """
     log.debug(f"Extracting archive {source_archive} to directory {target_directory}")
-    if is_tar_archive(source_archive):
+    if tarsafe.is_tarfile(source_archive):
 
         def add_exec(path):
             st = os.stat(path)
@@ -82,7 +65,7 @@ def safe_extract(source_archive: str, target_directory: str) -> None:
         tarsafe.open(source_archive).extractall(target_directory)
         recurse_add_perms(target_directory)
 
-    elif is_zip_archive(source_archive):
+    elif zipfile.is_zipfile(source_archive):
         with zipfile.ZipFile(source_archive, 'r') as zip:
             for file in zip.namelist():
                 # Note: zip.extract cleans up any malicious file name

--- a/guarddog/utils/archives.py
+++ b/guarddog/utils/archives.py
@@ -21,7 +21,9 @@ def is_supported_archive(path: str) -> bool:
 
     """
     def is_tar_archive(path: str) -> bool:
-        return any(path.endswith(ext) for ext in [".tar.gz", ".tgz"])
+        tar_exts = [".bz2", ".bzip2", ".gz", ".gzip", ".tgz", ".xz"]
+
+        return any(path.endswith(ext) for ext in tar_exts)
 
     def is_zip_archive(path: str) -> bool:
         return any(path.endswith(ext) for ext in [".zip", ".whl", ".egg"])

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -1,5 +1,8 @@
 import unittest
 import unittest.mock as mock
+import zipfile
+
+import tarsafe
 
 import guarddog.cli
 from guarddog.ecosystems import ECOSYSTEM
@@ -99,10 +102,10 @@ class TestCli(unittest.TestCase):
                 isfile.return_value = True
                 # The next two patches are to make sure we don't try
                 # to extract the test filename
-                with mock.patch("guarddog.utils.archives.is_tar_archive") as istar:
-                    istar.return_value = False
-                    with mock.patch("guarddog.utils.archives.is_zip_archive") as iszip:
-                        iszip.return_value = False
+                with mock.patch("tarsafe.is_tarfile") as is_tar:
+                    is_tar.return_value = False
+                    with mock.patch("zipfile.is_zipfile") as is_zip:
+                        is_zip.return_value = False
                         with mock.patch.object(scanner.PackageScanner, 'scan_local', return_value={}) as _:
                             try:
                                 with self.assertLogs("guarddog", level="DEBUG") as cm:


### PR DESCRIPTION
This PR changes GuardDog so that `bzip2` and `xz` compression are allowed when sourcing a package from a tar archive.  It also permits all common file extensions for these (`.bz2`, `.bzip2`, `.xz`) as well as for `gzip` (`.gz`, `.gzip`), which was already allowed in this context.

For local files, the PR uses the validation functions provided by `tarsafe` and `zipfile` to introspect the file contents (as opposed to just looking at the extension) before attempting to extract.

Closes #427 