### PR TITLE
Compute SHA-256 in bundled_binary

### DIFF
--- a/guarddog/analyzer/metadata/bundled_binary.py
+++ b/guarddog/analyzer/metadata/bundled_binary.py
@@ -1,10 +1,10 @@
-from guarddog.analyzer.metadata.detector import Detector
 from abc import abstractmethod
-from typing import Optional
-import os
-from functools import reduce
-import logging
 import hashlib
+import logging
+import os
+from typing import Optional
+
+from guarddog.analyzer.metadata.detector import Detector
 
 log = logging.getLogger("guarddog")
 

--- a/guarddog/analyzer/metadata/bundled_binary.py
+++ b/guarddog/analyzer/metadata/bundled_binary.py
@@ -56,12 +56,14 @@ class BundledBinary(Detector):
                         bin_files[digest] = [format_file(f, kind)]
                     else:
                         bin_files[digest].append(format_file(f, kind))
-        if bin_files:
-            output_lines = '\n'.join(
-                f"{digest}: {', '.join(files)}" for digest, files in bin_files.items()
-            )
-            return True, f"Binary file/s detected in package:\n{output_lines}"
-        return False, ""
+
+        if not bin_files:
+            return False, ""
+
+        output_lines = '\n'.join(
+            f"{digest}: {', '.join(files)}" for digest, files in bin_files.items()
+        )
+        return True, f"Binary file/s detected in package:\n{output_lines}"
 
     def is_binary(self, path: str) -> Optional[str]:
         max_head = len(max(self.magic_bytes.values()))

--- a/guarddog/analyzer/metadata/bundled_binary.py
+++ b/guarddog/analyzer/metadata/bundled_binary.py
@@ -35,7 +35,8 @@ class BundledBinary(Detector):
         def sha256(file: str) -> str:
             with open(file, "rb") as f:
                 hasher = hashlib.sha256()
-                hasher.update(f.read())
+                while (chunk := f.read(4096)):
+                    hasher.update(chunk)
                 return hasher.hexdigest()
 
         log.debug(


### PR DESCRIPTION
This PR updates the `bundled_binary` metadata rule so that it includes `SHA256` hashes of the binary files it finds.

The output format is updated so that files are organized by unique hash.  Each file listed on the same line has the same hash.  These listed files are all distinct, even if they have the same name.

Sample output:

```bash
$ guarddog npm scan sample-package --version 1.1.0 --rules bundled_binary
Found 1 potentially malicious indicators in sample-package

bundled_binary: Binary file/s detected in package:
843b9ff549ab7a1d4a7d60cd224321058029350a88ccb53855969f3a8649a342: conpty.dll (exe), conpty.dll (exe), c.dll (exe)
c081c868cc3c6dc5ca6c950772cd04644c326a18e9727fb188683f214d517409: OpenConsole.exe (exe)
0269664950a8bc65f9d30cb1d64213b3fc50507a3c56c174516d3ae243cbc3e0: conpty.dll (exe)
1ac1552204d73b82873d253e66303fa3acfdbac2a0650f23b57c3450682afe56: OpenConsole.exe (exe)
```