### PR TITLE
Enhance shady links rule 

### DIFF
--- a/guarddog/analyzer/sourcecode/shady-links.yml
+++ b/guarddog/analyzer/sourcecode/shady-links.yml
@@ -34,7 +34,7 @@ rules:
             - pattern-regex: ((?:https?:\/\/)?[^\n\[\/\?#"']*?(bit\.ly|discord\.com|workers\.dev|transfer\.sh|filetransfer\.io|sendspace\.com|appdomain\.cloud|backblazeb2\.com\|paste\.ee|ngrok\.io|termbin\.com|localhost\.run|webhook\.site|oastify\.com|burpcollaborator\.me)\b)
             - pattern-regex: ((?:https?:\/\/)?[^\n\[\/\?#"']*?(oast\.(pro|live|site|online|fun|me)|api\.telegram\.org|rentry\.co|ngrok-free\.(app|dev))\b)
             # top-level domains
-            - pattern-regex: (https?:\/\/[^\n\[\/\?#"']*?\.(link|xyz|tk|ml|ga|cf|gq|pw|top|club|mw|bd|ke|am|sbs|date|quest|cd|bid|cd|ws|icu|cam|uno|email|stream)\b)
+            - pattern-regex: (https?:\/\/[^\n\[\/\?#"']*?\.(link|xyz|tk|ml|ga|cf|gq|pw|top|club|mw|bd|ke|am|sbs|date|quest|cd|bid|cd|ws|icu|cam|uno|email|stream)\/)
             # IPv4
             - pattern-regex: (https?:\/\/[^\n\[\/\?#"']*?(?:\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}))
             # IPv6

--- a/guarddog/analyzer/sourcecode/shady-links.yml
+++ b/guarddog/analyzer/sourcecode/shady-links.yml
@@ -31,10 +31,10 @@ rules:
         - pattern: ("...")
         - pattern-either:
             # complete domains
-            - pattern-regex: ((?:https?:\/\/)?[^\n\[\/\?#"']*?(bit\.ly|discord\.com|workers\.dev|transfer\.sh|filetransfer\.io|sendspace\.com|appdomain\.cloud|backblazeb2\.com\|paste\.ee|ngrok\.io|termbin\.com|localhost\.run|webhook\.site|oastify\.com|burpcollaborator\.me)\/)
-            - pattern-regex: ((?:https?:\/\/)?[^\n\[\/\?#"']*?(oast\.(pro|live|site|online|fun|me)|api\.telegram\.org|rentry\.co)\/)
+            - pattern-regex: ((?:https?:\/\/)?[^\n\[\/\?#"']*?(bit\.ly|discord\.com|workers\.dev|transfer\.sh|filetransfer\.io|sendspace\.com|appdomain\.cloud|backblazeb2\.com\|paste\.ee|ngrok\.io|termbin\.com|localhost\.run|webhook\.site|oastify\.com|burpcollaborator\.me)\b)
+            - pattern-regex: ((?:https?:\/\/)?[^\n\[\/\?#"']*?(oast\.(pro|live|site|online|fun|me)|api\.telegram\.org|rentry\.co|ngrok-free\.(app|dev))\b)
             # top-level domains
-            - pattern-regex: (https?:\/\/[^\n\[\/\?#"']*?\.(link|xyz|tk|ml|ga|cf|gq|pw|top|club|mw|bd|ke|am|sbs|date|quest|cd|bid|cd|ws|icu|cam|uno|email|stream)\/)
+            - pattern-regex: (https?:\/\/[^\n\[\/\?#"']*?\.(link|xyz|tk|ml|ga|cf|gq|pw|top|club|mw|bd|ke|am|sbs|date|quest|cd|bid|cd|ws|icu|cam|uno|email|stream)\b)
             # IPv4
             - pattern-regex: (https?:\/\/[^\n\[\/\?#"']*?(?:\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}))
             # IPv6
@@ -46,6 +46,7 @@ rules:
         - "*/test_*"
     languages:
       - javascript
+      - json
       - python
       - typescript
       - go


### PR DESCRIPTION
This PR changes the matching on the rule to match on json files and also removal of the slash ending requirement for complete domains regex

No  false positives were observed in a test against the top 1k npm and pypi packages.