### PR TITLE
[SINT-2736] Add new GIthub Action ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,21 @@ Metadata heuristics:
 | typosquatting | Identify packages that are named closely to an highly popular package |
 
 
+### GitHub Action
+
+Source code heuristics:
+
+| **Heuristic** | **Description** |
+|:-------------:|:---------------:|
+| npm-serialize-environment | Identify when a package serializes 'process.env' to exfiltrate environment variables |
+| npm-obfuscation | Identify when a package uses a common obfuscation method often used by malware |
+| npm-silent-process-execution | Identify when a package silently executes an executable |
+| shady-links | Identify when a package contains an URL to a domain with a suspicious extension |
+| npm-exec-base64 | Identify when a package dynamically executes code through 'eval' |
+| npm-install-script | Identify when a package has a pre or post-install script automatically running commands |
+| npm-steganography | Identify when a package retrieves hidden data from an image and executes it |
+| npm-dll-hijacking | Identifies when a malicious package manipulates a trusted application into loading a malicious DLL |
+| npm-exfiltrate-sensitive-data | Identify when a package reads and exfiltrates sensitive data from the local system |
 <!-- END_RULE_LIST -->
 
 ## Custom Rules

--- a/guarddog/analyzer/metadata/__init__.py
+++ b/guarddog/analyzer/metadata/__init__.py
@@ -2,6 +2,7 @@ from guarddog.analyzer.metadata.detector import Detector
 from guarddog.analyzer.metadata.npm import NPM_METADATA_RULES
 from guarddog.analyzer.metadata.pypi import PYPI_METADATA_RULES
 from guarddog.analyzer.metadata.go import GO_METADATA_RULES
+from guarddog.analyzer.metadata.github_action import GITHUB_ACTION_METADATA_RULES
 from guarddog.ecosystems import ECOSYSTEM
 
 
@@ -13,3 +14,5 @@ def get_metadata_detectors(ecosystem: ECOSYSTEM) -> dict[str, Detector]:
             return NPM_METADATA_RULES
         case ECOSYSTEM.GO:
             return GO_METADATA_RULES
+        case ECOSYSTEM.GITHUB_ACTION:
+            return GITHUB_ACTION_METADATA_RULES

--- a/guarddog/analyzer/metadata/github_action/__init__.py
+++ b/guarddog/analyzer/metadata/github_action/__init__.py
@@ -1,0 +1,11 @@
+from typing import Type
+
+from guarddog.analyzer.metadata import Detector
+
+GITHUB_ACTION_METADATA_RULES = {}
+
+classes: list[Type[Detector]] = []
+
+for detectorClass in classes:
+    detectorInstance = detectorClass()  # type: ignore
+    GITHUB_ACTION_METADATA_RULES[detectorInstance.get_name()] = detectorInstance

--- a/guarddog/analyzer/sourcecode/__init__.py
+++ b/guarddog/analyzer/sourcecode/__init__.py
@@ -51,6 +51,9 @@ def get_sourcecode_rules(
         ecosystem: The ecosystem to filter for if rules are ecosystem specific
         kind: The kind of rule to filter for
     """
+    if ecosystem == ECOSYSTEM.GITHUB_ACTION:
+        ecosystem = ECOSYSTEM.NPM
+
     for rule in SOURCECODE_RULES:
         if kind and not isinstance(rule, kind):
             continue

--- a/guarddog/ecosystems.py
+++ b/guarddog/ecosystems.py
@@ -5,6 +5,7 @@ class ECOSYSTEM(Enum):
     PYPI = "pypi"
     NPM = "npm"
     GO = "go"
+    GITHUB_ACTION = "github-action"
 
 
 def get_friendly_name(ecosystem: ECOSYSTEM) -> str:
@@ -15,5 +16,7 @@ def get_friendly_name(ecosystem: ECOSYSTEM) -> str:
             return "npm"
         case ECOSYSTEM.GO:
             return "go"
+        case ECOSYSTEM.GITHUB_ACTION:
+            return "GitHub Action"
         case _:
             return ecosystem.value

--- a/guarddog/scanners/__init__.py
+++ b/guarddog/scanners/__init__.py
@@ -6,6 +6,7 @@ from .pypi_package_scanner import PypiPackageScanner
 from .pypi_project_scanner import PypiRequirementsScanner
 from .go_package_scanner import GoModuleScanner
 from .go_project_scanner import GoDependenciesScanner
+from .github_action_scanner import GithubActionScanner
 from .scanner import PackageScanner, ProjectScanner
 from ..ecosystems import ECOSYSTEM
 
@@ -29,6 +30,8 @@ def get_package_scanner(ecosystem: ECOSYSTEM) -> Optional[PackageScanner]:
             return NPMPackageScanner()
         case ECOSYSTEM.GO:
             return GoModuleScanner()
+        case ECOSYSTEM.GITHUB_ACTION:
+            return GithubActionScanner()
     return None
 
 

--- a/guarddog/scanners/github_action_scanner.py
+++ b/guarddog/scanners/github_action_scanner.py
@@ -1,0 +1,51 @@
+import logging
+import os
+import pathlib
+import typing
+from urllib.parse import urlparse
+
+from guarddog.analyzer.analyzer import Analyzer
+from guarddog.ecosystems import ECOSYSTEM
+from guarddog.scanners.scanner import PackageScanner
+
+log = logging.getLogger("guarddog")
+
+
+class GithubActionScanner(PackageScanner):
+    def __init__(self) -> None:
+        super().__init__(Analyzer(ECOSYSTEM.GITHUB_ACTION))
+
+    def download_and_get_package_info(self, directory: str, package_name: str, version=None) -> typing.Tuple[dict, str]:
+        repo = self._get_repo(package_name)
+        tarball_url = self._get_git_tarball_url(repo, version)
+
+        log.debug(f"Downloading GitHub Action source from {tarball_url}")
+
+        file_extension = pathlib.Path(tarball_url).suffix
+        if file_extension == "":
+            file_extension = ".zip"
+
+        zippath = os.path.join(directory, package_name.replace("/", "-") + file_extension)
+        unzippedpath = zippath.removesuffix(file_extension)
+        self.download_compressed(tarball_url, zippath, unzippedpath)
+
+        return {}, unzippedpath
+
+    def _get_repo(self, url: str) -> str:
+        parsed_url = urlparse(url)
+
+        if parsed_url.hostname and parsed_url.hostname != "github.com":
+            raise Exception(parsed_url)
+
+        path = parsed_url.path.removesuffix(".git").strip("/")
+
+        if path.count("/") != 1:
+            raise Exception("Invalid GitHub repo URL: " + url)
+
+        return path
+
+    def _get_git_tarball_url(self, repo: str, version=None) -> str:
+        if not version:
+            return f"https://api.github.com/repos/{repo}/zipball"
+        else:
+            return f"https://github.com/{repo}/archive/refs/tags/{version}.zip"

--- a/tests/core/test_github_action_scanner.py
+++ b/tests/core/test_github_action_scanner.py
@@ -1,0 +1,22 @@
+import os.path
+import tempfile
+
+import pytest
+
+from guarddog.scanners import GithubActionScanner
+
+
+def test_download_and_get_github_action_by_url():
+    scanner = GithubActionScanner()
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        data, path = scanner.download_and_get_package_info(tmpdirname, "https://github.com/expressjs/express.git", "v5.0.0")
+        assert not data
+        assert os.path.exists(os.path.join(tmpdirname, "https:--github.com-expressjs-express.git", "express-5.0.0", "package.json"))
+
+
+def test_download_and_get_github_action_by_name():
+    scanner = GithubActionScanner()
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        data, path = scanner.download_and_get_package_info(tmpdirname, "expressjs/express", "v5.0.0")
+        assert not data
+        assert os.path.exists(os.path.join(tmpdirname, "expressjs-express", "express-5.0.0", "package.json"))


### PR DESCRIPTION
After discussions with the team about https://github.com/DataDog/guarddog/pull/526, it seems having a dedicated ecosystem for github actions would be better from a UX point of view. 

This PR makes the required changes to support scanning GitHub Action's JS (or TS) code using existing NPM source code rules.