### PR TITLE
Added zip domain to shadylinks check

### DIFF
--- a/guarddog/analyzer/sourcecode/shady-links.yml
+++ b/guarddog/analyzer/sourcecode/shady-links.yml
@@ -41,7 +41,7 @@ rules:
             - pattern-regex: ((?:https?:\/\/)?[^\n\[\/\?#"']*?(ipinfo\.io|checkip\.dyndns\.org|\bip\.me|jsonip\.com|ipify\.org|ifconfig\.me)\b)
 
             # top-level domains
-            - pattern-regex: (https?:\/\/[^\n\[\/\?#"']*?\.(link|xyz|tk|ml|ga|cf|gq|pw|top|club|mw|bd|ke|am|sbs|date|quest|cd|bid|cd|ws|icu|cam|uno|email|stream)\/)
+            - pattern-regex: (https?:\/\/[^\n\[\/\?#"']*?\.(link|xyz|tk|ml|ga|cf|gq|pw|top|club|mw|bd|ke|am|sbs|date|quest|cd|bid|cd|ws|icu|cam|uno|email|stream|zip)\/)
             # IPv4
             - pattern-regex: (https?:\/\/[^\n\[\/\?#"']*?(?:\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}))
             # IPv6


### PR DESCRIPTION
Since domain providers now allow to buy .zip it can be used to bypass checks