### PR TITLE
Update top-pypi-packages filename

### DIFF
--- a/guarddog/analyzer/metadata/pypi/typosquatting.py
+++ b/guarddog/analyzer/metadata/pypi/typosquatting.py
@@ -39,7 +39,7 @@ class PypiTyposquatDetector(TyposquatDetector):
                 }
         """
 
-        popular_packages_url = "https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json"
+        popular_packages_url = "https://hugovk.github.io/top-pypi-packages/top-pypi-packages.min.json"
 
         top_packages_filename = "top_pypi_packages.json"
         resources_dir = TOP_PACKAGES_CACHE_LOCATION

--- a/tests/samples/download_legit_pypi_package.sh
+++ b/tests/samples/download_legit_pypi_package.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-TOP_PYPI_PACKAGE="https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json"
+TOP_PYPI_PACKAGE="https://hugovk.github.io/top-pypi-packages/top-pypi-packages.min.json"
 REQUIREMENT_FILE="legit_top_packages.txt"
 
 if [ -z "$1" ]; then


### PR DESCRIPTION
To stay within quota, it now has just under 30 days of data, so the filename has been updated. Both will be available for a while. See https://github.com/hugovk/top-pypi-packages/pull/46.