### PR TITLE
Semgrep timeout fix + use of env variables to set max_target_bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,12 @@ flake8 guarddog --count --select=E9,F63,F7,F82 --show-source --statistics --excl
 flake8 guarddog --count --max-line-length=120 --statistics --exclude tests/analyzer/sourcecode,tests/analyzer/metadata/resources,evaluator/data --ignore=E203,W503
 ```
 
+### Semgrep configuration
+
+Guarddog uses `Semgrep`, a powerful static analysis tool that scans code for patterns. \\
+The `max_target_bytes` setting, which controls the maximum size of a file that Semgrep will analyze, can be adjusted using the environment variable `GUARDDOG_SEMGREP_MAX_TARGET_BYTES`. \\
+By default, this value is set to 10MB; files exceeding this limit will be skipped during analysis to optimize performance and resource usage.
+
 ## Maintainers
 
 Authors:

--- a/README.md
+++ b/README.md
@@ -334,9 +334,13 @@ flake8 guarddog --count --max-line-length=120 --statistics --exclude tests/analy
 
 ### Semgrep configuration
 
-Guarddog uses `Semgrep`, a powerful static analysis tool that scans code for patterns. \\
-The `max_target_bytes` setting, which controls the maximum size of a file that Semgrep will analyze, can be adjusted using the environment variable `GUARDDOG_SEMGREP_MAX_TARGET_BYTES`. \\
+Guarddog uses `Semgrep`, a powerful static analysis tool that scans code for patterns. 
+
+The `max_target_bytes` setting, which controls the maximum size of a file that Semgrep will analyze, can be adjusted using the environment variable `GUARDDOG_SEMGREP_MAX_TARGET_BYTES`. 
 By default, this value is set to 10MB; files exceeding this limit will be skipped during analysis to optimize performance and resource usage.
+
+Additionally, the timeout setting, which specifies the maximum time in seconds that Semgrep will spend running a rule on a single file,  can be configured via the GUARDDOG_SEMGREP_TIMEOUT environment variable. The default value is 10 seconds.
+
 
 ## Maintainers
 

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ Guarddog uses `Semgrep`, a powerful static analysis tool that scans code for pat
 The `max_target_bytes` setting, which controls the maximum size of a file that Semgrep will analyze, can be adjusted using the environment variable `GUARDDOG_SEMGREP_MAX_TARGET_BYTES`. 
 By default, this value is set to 10MB; files exceeding this limit will be skipped during analysis to optimize performance and resource usage.
 
-Additionally, the timeout setting, which specifies the maximum time in seconds that Semgrep will spend running a rule on a single file,  can be configured via the GUARDDOG_SEMGREP_TIMEOUT environment variable. The default value is 10 seconds.
+Additionally, the timeout setting, which specifies the maximum time in seconds that Semgrep will spend running a rule on a single file,  can be configured via the `GUARDDOG_SEMGREP_TIMEOUT` environment variable. The default value is 10 seconds.
 
 
 ## Maintainers

--- a/guarddog/analyzer/analyzer.py
+++ b/guarddog/analyzer/analyzer.py
@@ -277,8 +277,10 @@ class Analyzer:
 
     def _invoke_semgrep(self, target: str, rules: Iterable[str]):
         try:
-            SEMGREP_MAX_TARGET_BYTES = int(os.getenv("GUARDDOG_SEMGREP_MAX_TARGET_BYTES", MAX_BYTES_DEFAULT))
-            SEMGREP_TIMEOUT = int(os.getenv("GUARDDOG_SEMGREP_TIMEOUT", SEMGREP_TIMEOUT_DEFAULT))
+            SEMGREP_MAX_TARGET_BYTES = int(
+                os.getenv("GUARDDOG_SEMGREP_MAX_TARGET_BYTES", MAX_BYTES_DEFAULT))
+            SEMGREP_TIMEOUT = int(
+                os.getenv("GUARDDOG_SEMGREP_TIMEOUT", SEMGREP_TIMEOUT_DEFAULT))
             cmd = ["semgrep"]
             for rule in rules:
                 cmd.extend(["--config", rule])

--- a/guarddog/analyzer/analyzer.py
+++ b/guarddog/analyzer/analyzer.py
@@ -15,7 +15,7 @@ from guarddog.ecosystems import ECOSYSTEM
 
 SEMGREP_MAX_TARGET_BYTES = int(
     os.getenv("GUARDDOG_SEMGREP_MAX_TARGET_BYTES", 10_000_000)
-)  # default to 10MB if no env variable found 
+)  # default to 10MB if no env variable found
 SEMGREP_TIMEOUT = 10  # maximum time to spend running a rule on a single file in seconds.
 SOURCECODE_RULES_PATH = os.path.join(
     os.path.dirname(__file__), "sourcecode"

--- a/guarddog/analyzer/analyzer.py
+++ b/guarddog/analyzer/analyzer.py
@@ -13,9 +13,10 @@ from guarddog.analyzer.sourcecode import get_sourcecode_rules, SempgrepRule, Yar
 from guarddog.utils.config import YARA_EXT_EXCLUDE
 from guarddog.ecosystems import ECOSYSTEM
 
-SEMGREP_MAX_TARGET_BYTES = int(os.getenv("GUARDDOG_SEMGREP_MAX_TARGET_BYTES", 10_000_000)) # default to 10MB if no env variable found
-SOURCECODE_RULES_PATH = os.path.join(os.path.dirname(__file__), "sourcecode")
-SEMGREP_TIMEOUT = 10 # maximum time to spend running a rule on a single file in seconds.
+SEMGREP_MAX_TARGET_BYTES = int(
+    os.getenv("GUARDDOG_SEMGREP_MAX_TARGET_BYTES", 10_000_000)
+)  # default to 10MB if no env variable foundSOURCECODE_RULES_PATH = os.path.join(os.path.dirname(__file__), "sourcecode")
+SEMGREP_TIMEOUT = 10  # maximum time to spend running a rule on a single file in seconds.
 
 log = logging.getLogger("guarddog")
 
@@ -281,7 +282,7 @@ class Analyzer:
 
             for excluded in self.exclude:
                 cmd.append(f"--exclude='{excluded}'")
-            cmd.append("--timeout", str(SEMGREP_TIMEOUT))
+            cmd.extend("--timeout", str(SEMGREP_TIMEOUT))
             cmd.append("--no-git-ignore")
             cmd.append("--json")
             cmd.append("--quiet")

--- a/guarddog/analyzer/analyzer.py
+++ b/guarddog/analyzer/analyzer.py
@@ -17,6 +17,7 @@ SEMGREP_MAX_TARGET_BYTES = int(
     os.getenv("GUARDDOG_SEMGREP_MAX_TARGET_BYTES", 10_000_000)
 )  # default to 10MB if no env variable found SOURCECODE_RULES_PATH = os.path.join(os.path.dirname(__file__), "sourcecode")
 SEMGREP_TIMEOUT = 10  # maximum time to spend running a rule on a single file in seconds.
+SOURCECODE_RULES_PATH = os.path.join(os.path.dirname(__file__), "sourcecode")
 
 log = logging.getLogger("guarddog")
 

--- a/guarddog/analyzer/analyzer.py
+++ b/guarddog/analyzer/analyzer.py
@@ -13,8 +13,9 @@ from guarddog.analyzer.sourcecode import get_sourcecode_rules, SempgrepRule, Yar
 from guarddog.utils.config import YARA_EXT_EXCLUDE
 from guarddog.ecosystems import ECOSYSTEM
 
-SEMGREP_MAX_TARGET_BYTES = 10_000_000
+SEMGREP_MAX_TARGET_BYTES = int(os.getenv("GUARDDOG_SEMGREP_MAX_TARGET_BYTES", 10_000_000)) # default to 10MB if no env variable found
 SOURCECODE_RULES_PATH = os.path.join(os.path.dirname(__file__), "sourcecode")
+SEMGREP_TIMEOUT = 10 # maximum time to spend running a rule on a single file in seconds.
 
 log = logging.getLogger("guarddog")
 
@@ -280,6 +281,7 @@ class Analyzer:
 
             for excluded in self.exclude:
                 cmd.append(f"--exclude='{excluded}'")
+            cmd.append("--timeout", str(SEMGREP_TIMEOUT))
             cmd.append("--no-git-ignore")
             cmd.append("--json")
             cmd.append("--quiet")

--- a/guarddog/analyzer/analyzer.py
+++ b/guarddog/analyzer/analyzer.py
@@ -15,9 +15,11 @@ from guarddog.ecosystems import ECOSYSTEM
 
 SEMGREP_MAX_TARGET_BYTES = int(
     os.getenv("GUARDDOG_SEMGREP_MAX_TARGET_BYTES", 10_000_000)
-)  # default to 10MB if no env variable found SOURCECODE_RULES_PATH = os.path.join(os.path.dirname(__file__), "sourcecode")
+)  # default to 10MB if no env variable found 
 SEMGREP_TIMEOUT = 10  # maximum time to spend running a rule on a single file in seconds.
-SOURCECODE_RULES_PATH = os.path.join(os.path.dirname(__file__), "sourcecode")
+SOURCECODE_RULES_PATH = os.path.join(
+    os.path.dirname(__file__), "sourcecode"
+)
 
 log = logging.getLogger("guarddog")
 

--- a/guarddog/analyzer/analyzer.py
+++ b/guarddog/analyzer/analyzer.py
@@ -15,7 +15,7 @@ from guarddog.ecosystems import ECOSYSTEM
 
 SEMGREP_MAX_TARGET_BYTES = int(
     os.getenv("GUARDDOG_SEMGREP_MAX_TARGET_BYTES", 10_000_000)
-)  # default to 10MB if no env variable foundSOURCECODE_RULES_PATH = os.path.join(os.path.dirname(__file__), "sourcecode")
+)  # default to 10MB if no env variable found SOURCECODE_RULES_PATH = os.path.join(os.path.dirname(__file__), "sourcecode")
 SEMGREP_TIMEOUT = 10  # maximum time to spend running a rule on a single file in seconds.
 
 log = logging.getLogger("guarddog")
@@ -282,7 +282,7 @@ class Analyzer:
 
             for excluded in self.exclude:
                 cmd.append(f"--exclude='{excluded}'")
-            cmd.extend("--timeout", str(SEMGREP_TIMEOUT))
+            cmd.append(f"--timeout={SEMGREP_TIMEOUT}")
             cmd.append("--no-git-ignore")
             cmd.append("--json")
             cmd.append("--quiet")


### PR DESCRIPTION
Timeout is set to 10 seconds
Use of GUARDDOG_SEMGREP_MAX_TARGET_BYTES env variable (default is 10MB) instead of a hard coded constant
Updated README informing users of this configuration change