### PR TITLE
Fix scan on empty python dependencies

### DIFF
--- a/guarddog/scanners/pypi_project_scanner.py
+++ b/guarddog/scanners/pypi_project_scanner.py
@@ -76,8 +76,11 @@ class PypiRequirementsScanner(ProjectScanner):
 
             # Filters to specified versions
             try:
-                spec = Specifier(semver_range)
-                result = [Version(m) for m in spec.filter(versions)]
+                matching_versions = versions
+                if semver_range:
+                    spec = Specifier(semver_range)
+                    matching_versions = set(spec.filter(versions))
+                result = [Version(m) for m in matching_versions]
             except ValueError:
                 # use it raw
                 return set([semver_range])

--- a/tests/core/test_npm_requirements_scanner.py
+++ b/tests/core/test_npm_requirements_scanner.py
@@ -10,12 +10,18 @@ def test_npm_requirements_scanner():
     {
         "dependencies": {
             "non-existing": "*",
-            "express": "4.x"
+            "express": "4.x",
+            "cors": "*"
         }
     }
     """)
     assert "non-existing" not in result  # ignoring non existing packages
     assert "express" in result
+    lookup = next(
+        filter(lambda r: r.name == "cors", result), None
+    )
+    assert lookup is not None
+    assert len(lookup.versions) == 1
 
 
 def test_npm_find_requirements():

--- a/tests/core/test_pypi_requirements_scanner.py
+++ b/tests/core/test_pypi_requirements_scanner.py
@@ -39,6 +39,7 @@ def test_requirements_scanner_on_git_url_packages():
                 "https://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl",
                 "guarddog @ git+https://github.com/DataDog/guarddog.git",
                 "git+https://github.com/DataDog/guarddog.git",
+                "requests",
             ]
         )
     )
@@ -48,4 +49,10 @@ def test_requirements_scanner_on_git_url_packages():
     assert lookup is not None
     assert "git+https://github.com/DataDog/guarddog.git" in [v.version for v in lookup.versions]
     assert "flask" in result
-    assert len(result) == 2
+    assert len(result) == 3
+    lookup = next(
+        filter(lambda r: r.name == "requests", result), None
+    )
+    assert lookup is not None
+    assert len(lookup.versions) == 1
+ 


### PR DESCRIPTION
A requirements file declaring dependencies with no versions would end up not scanning the latest version.

For instance:
```
$ cat /tmp/requirements.txt
disposable-email-domains
```

Would produce:
```
Some rules failed to run while scanning disposable-email-domains:

* download-package: Version  for package disposable-email-domains doesn't exist.%
```

This PR would result in:
```
guarddog --log-level DEBUG pypi verify /tmp/requirements.txt --output-format sarif --exclude-rules repository_integrity_mismatch
DEBUG: Retrieving PyPI package metadata information from https://pypi.org/pypi/disposable-email-domains/json
DEBUG: Retrieved versions 0.0.98, 0.0.124, 0.0.40, 0.0.103, 0.0.93, 0.0.73, 0.0.91, 0.0.68, 0.0.24, 0.0.74, 0.0.38, 0.0.22, 0.0.110, 0.0.94, 0.0.39, 0.0.67, 0.0.102, 0.0.30, 0.0.109, 0.0.48, 0.0.51, 0.0.55, 0.0.96, 0.0.56, 0.0.18, 0.0.15, 0.0.14, 0.0.114, 0.0.119, 0.0.36, 0.0.13, 0.0.87, 0.0.44, 0.0.99, 0.0.27, 0.0.10, 0.0.9, 0.0.118, 0.0.120, 0.0.3, 0.0.111, 0.0.57, 0.0.61, 0.0.16, 0.0.65, 0.0.37, 0.0.72, 0.0.23, 0.0.20, 0.0.49, 0.0.108, 0.0.7, 0.0.76, 0.0.83, 0.0.11, 0.0.2, 0.0.26, 0.0.115, 0.0.31, 0.0.32, 0.0.97, 0.0.52, 0.0.50, 0.0.6, 0.0.4, 0.0.113, 0.0.89, 0.0.69, 0.0.60, 0.0.19, 0.0.25, 0.0.8, 0.0.29, 0.0.42, 0.0.101, 0.0.71, 0.0.64, 0.0.43, 0.0.81, 0.0.54, 0.0.121, 0.0.59, 0.0.122, 0.0.84, 0.0.66, 0.0.53, 0.0.95, 0.0.116, 0.0.46, 0.0.123, 0.0.45, 0.0.77, 0.0.79, 0.0.34, 0.0.126, 0.0.125, 0.0.117, 0.0.41, 0.0.107, 0.0.85, 0.0.12, 0.0.86, 0.0.92, 0.0.21, 0.0.100, 0.0.80, 0.0.70, 0.0.28, 0.0.58, 0.0.63, 0.0.90, 0.0.112, 0.0.17, 0.0.33, 0.0.82, 0.0.5, 0.0.105, 0.0.104, 0.0.35, 0.0.62, 0.0.106, 0.0.75, 0.0.47, 0.0.1, 0.0.78
INFO: Scanning using at most 10 parallel worker threads

DEBUG: Scanning disposable-email-domains version 0.0.126
DEBUG: Retrieving PyPI package metadata from https://pypi.org/pypi/disposable-email-domains/json
...
```