### PR TITLE
Adding case detection for DLL loading

### DIFF
--- a/guarddog/analyzer/sourcecode/dll-hijacking.yml
+++ b/guarddog/analyzer/sourcecode/dll-hijacking.yml
@@ -55,8 +55,13 @@ rules:
       # dll injection
       - pattern-either:
         - pattern: ....WriteProcessMemory
+        - pattern: getattr(..., "WriteProcessMemory")
         - pattern: ....CreateRemoteThread
+        - pattern: getattr(..., "CreateRemoteThread")
         - pattern: ....LoadLibraryA
+        - pattern: getattr(..., "LoadLibraryA")
+        - pattern: ....CDLL
+        - pattern: getattr(..., "CDLL")
 
       # phantom dll
       - patterns:

--- a/tests/analyzer/sourcecode/dll-hijacking.py
+++ b/tests/analyzer/sourcecode/dll-hijacking.py
@@ -169,3 +169,10 @@ def f():
     # ok: dll-hijacking
     # This is comment that mentions LD_PRELOAD
     pass
+
+def f():
+    here = os.path.abspath(os.path.dirname(__file__))
+    ct = getattr(sys.modules[__name__], "ctypes")
+    # ruleid: dll-hijacking
+    help = getattr(ct, "CDLL")(os.path.join(here, "_build.py"))
+    getattr(help, "main")()


### PR DESCRIPTION
In light of the num2words compromised lib case