### PR TITLE
Update PyPI publish workflow to use Trusted Publisher

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -11,6 +11,9 @@ permissions:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    environment: protected-main-env
+    permissions:
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
@@ -31,7 +34,5 @@ jobs:
           poetry build
 
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
-        with:
-          password: ${{ secrets.PYPI_PUBLISH_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         


### PR DESCRIPTION
This PR updates the `pypi-release.yml` GitHub Action to use Datadog's Trusted Publisher.