### PR TITLE
recursively analyze local imports in pypi source code

### DIFF
--- a/guarddog/analyzer/analyzer.py
+++ b/guarddog/analyzer/analyzer.py
@@ -3,6 +3,7 @@ import logging
 import os
 import subprocess
 import yara  # type: ignore
+import ast
 
 from collections import defaultdict
 from pathlib import Path
@@ -153,6 +154,7 @@ class Analyzer:
     def analyze_sourcecode(self, path, rules=None) -> dict:
         """
         Analyzes the source code of a given package
+        If setup.py, code-execution.py, or __init__.py exists, scans those files and their local imports
 
         Args:
             path (str): path to directory of package
@@ -161,8 +163,25 @@ class Analyzer:
         Returns:
             dict[str]: map from each source code rule and their corresponding output
         """
-        semgrepscan_results = self.analyze_semgrep(path, rules)
+        path_obj = Path(path)
+        target_files = self._find_target_files(path_obj)
 
+        if target_files:
+            files_to_scan = [str(f) for f in target_files]
+
+            # Resolve and add imported files
+            project_root = path_obj if path_obj.is_dir() else path_obj.parent
+            for target_file in target_files:
+                imported_files = self._resolve_local_imports(str(target_file), str(project_root))
+                files_to_scan.extend(imported_files)
+
+            # Remove duplicates
+            files_to_scan = list(dict.fromkeys(files_to_scan))
+
+        else:
+            files_to_scan = path
+
+        semgrepscan_results = self.analyze_semgrep(files_to_scan, rules)
         yarascan_results = self.analyze_yara(path, rules)
 
         # Concatenate dictionaries together
@@ -171,6 +190,186 @@ class Analyzer:
         errors = semgrepscan_results["errors"] | yarascan_results["errors"]
 
         return {"issues": issues, "errors": errors, "results": results, "path": path}
+
+    def _find_target_files(self, path_obj: Path) -> list[Path]:
+        """
+        Find target files in the given path
+
+        Args:
+            path_obj (Path): directory or file path to search for target files
+
+        Returns:
+            list[Path]: list of Path objects that matches found target files
+        """
+        target_names = ["setup.py", "code-execution.py", "__init__.py"]
+        found_files = []
+
+        if not path_obj.is_dir():
+            return [path_obj] if path_obj.name in target_names else []
+
+        # Check root dir
+        for target_name in target_names:
+            if (path_obj / target_name).exists():
+                found_files.append(path_obj / target_name)
+
+        # Check one level deep in case root directory contains nothing but the package dir
+        for item in path_obj.iterdir():
+            if item.is_dir():
+                for target_name in target_names:
+                    if (item / target_name).exists():
+                        found_files.append(item / target_name)
+
+        return found_files
+
+    def _resolve_local_imports(self, file_path: str, project_root: str, seen: Optional[set] = None, depth: int = 0,
+                               max_depth: int = 50) -> set:
+        """
+        Recursively resolve all local imports from a given file
+
+        Args:
+            file_path (str): path to the Python file to analyze
+            project_root (str): root directory of the project
+            seen (set, optional): set of processed files
+            depth (int): current recursion depth
+            max_depth (int): maximum recursion depth
+
+        Returns:
+            set: set of absolute paths to locally imported files
+        """
+        if seen is None:
+            seen = set()
+
+        if depth > max_depth:
+            log.warning(f"Exceeded maximum import depth ({max_depth}) at {file_path}.")
+            return set()
+
+        file_path_obj = Path(file_path).resolve()
+        project_root_obj = Path(project_root).resolve()
+
+        if str(file_path_obj) in seen:
+            return set()
+        seen.add(str(file_path_obj))
+
+        try:
+            with open(file_path_obj, "r", encoding="utf-8") as f:
+                tree = ast.parse(f.read(), filename=str(file_path_obj))
+        except Exception as e:
+            log.debug(f"Failed to parse {file_path_obj}: {e}")
+            return set()
+
+        imported_files: set[str] = set()
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    module_name = alias.name.split(".")[0]  # Get top level module
+                    self._add_if_local(module_name, file_path_obj, project_root_obj, imported_files, seen, depth)
+
+            elif isinstance(node, ast.ImportFrom):
+                if node.level > 0:  # Relative import
+                    base_path = file_path_obj.parent
+                    for _ in range(node.level - 1):
+                        base_path = base_path.parent
+
+                    module_name = node.module.split(".")[0] if node.module else ""
+                    if module_name:
+                        self._check_relative_import(module_name, base_path, project_root_obj, imported_files,
+                                                    seen, depth)
+                    else:
+                        # from . import x
+                        for alias in node.names:
+                            self._check_relative_import(alias.name, base_path, project_root_obj, imported_files,
+                                                        seen, depth)
+                elif node.module and "." not in node.module:
+                    # Absolute import of simple module
+                    self._add_if_local(node.module, file_path_obj, project_root_obj, imported_files, seen, depth)
+
+        return imported_files
+
+    def _add_if_local(self, module_name: str, current_file: Path, project_root: Path, imported_files: set[str],
+                      seen: set, depth: int) -> None:
+        """
+        Add module to imported_files set if it exists locally within the project
+
+        Args:
+            module_name (str): name of the module to check
+            current_file (Path): path of the file performing the import
+            project_root (Path): root directory of the project
+            imported_files (set[str]): set of already identified imported file paths
+            seen (set): set of files already processed
+            depth (int): current recursion depth
+
+        Returns:
+            None
+        """
+        candidates = [
+            project_root / f"{module_name}.py",
+            project_root / module_name / "__init__.py",
+            current_file.parent / f"{module_name}.py",
+            current_file.parent / module_name / "__init__.py",
+        ]
+
+        for candidate in candidates:
+            if self._is_valid_local_file(candidate, project_root, seen):
+                imported_files.add(str(candidate))
+                imported_files.update(
+                    self._resolve_local_imports(str(candidate), str(project_root), seen, depth + 1)
+                )
+                return
+
+    def _check_relative_import(self, name: str, base_path: Path, project_root: Path, imported_files: set[str],
+                               seen: set, depth: int) -> None:
+        """
+        Resolve a relative import and add the corresponding file to the imported_files set
+
+        Args:
+            name (str): module or file name to resolve
+            base_path (Path): base directory for relative import resolution
+            project_root (Path): root directory of the project
+            imported_files (set[str]): set of already identified imported file paths
+            seen (set): set of files already processed
+            depth (int): current recursion depth
+
+        Returns:
+            None
+        """
+        candidates = [
+            base_path / f"{name}.py",
+            base_path / name / "__init__.py",
+        ]
+
+        for candidate in candidates:
+            if self._is_valid_local_file(candidate, project_root, seen):
+                imported_files.add(str(candidate))
+                imported_files.update(
+                    self._resolve_local_imports(str(candidate), str(project_root), seen, depth + 1)
+                )
+                return
+
+    def _is_valid_local_file(self, candidate: Path, project_root: Path, seen: set) -> bool:
+        """
+        Check if a candidate file exists, is within project, and hasn't been seen
+
+        Args:
+            candidate (Path): file path to validate
+            project_root (Path): root directory of the project
+            seen (set): set of already processed file paths
+
+        Returns:
+            bool: true if the file is valid and local, false otherwise
+        """
+        try:
+            candidate = candidate.resolve()
+            if not candidate.exists() or not candidate.is_file() or str(candidate) in seen:
+                return False
+
+            # Check if within project root
+            try:
+                return candidate.is_relative_to(project_root)
+            except AttributeError:  # Python < 3.9
+                return project_root in candidate.parents or candidate == project_root
+        except (OSError, ValueError):
+            return False
 
     def analyze_yara(self, path: str, rules: Optional[set] = None) -> dict:
         """
@@ -261,14 +460,18 @@ class Analyzer:
             dict[str]: map from each source code rule and their corresponding output
         """
         log.debug(f"Running semgrep rules against directory '{path}'")
+        # Convert single path to list
+        if isinstance(path, str):
+            path = [path]
 
-        targetpath = Path(path)
+        log.debug("Running semgrep rules")
+
         all_rules = self.semgrep_ruleset
         if rules is not None:
             # filtering the full ruleset witht the user's input
             all_rules = self.semgrep_ruleset & rules
 
-        results = {rule: {} for rule in all_rules}  # type: dict
+        results: Dict[str, dict] = {rule: {} for rule in all_rules}
         errors = {}
         issues = 0
 
@@ -287,10 +490,8 @@ class Analyzer:
 
         try:
             log.debug(f"Running semgrep code rules against {path}")
-            response = self._invoke_semgrep(target=path, rules=rules_path)
-            rule_results = self._format_semgrep_response(
-                response, targetpath=targetpath
-            )
+            response = self._invoke_semgrep(targets=path, rules=rules_path)
+            rule_results = self._format_semgrep_response(response)
             issues += sum(len(res) for res in rule_results.values())
 
             results = results | rule_results
@@ -299,7 +500,7 @@ class Analyzer:
 
         return {"results": results, "errors": errors, "issues": issues}
 
-    def _invoke_semgrep(self, target: str, rules: Iterable[str]):
+    def _invoke_semgrep(self, targets: list, rules: Iterable[str]):
         try:
             SEMGREP_MAX_TARGET_BYTES = int(
                 os.getenv("GUARDDOG_SEMGREP_MAX_TARGET_BYTES", MAX_BYTES_DEFAULT)
@@ -312,14 +513,16 @@ class Analyzer:
                 cmd.extend(["--config", rule])
 
             for excluded in self.exclude:
-                cmd.append(f"--exclude='{excluded}'")
+                cmd.extend(["--exclude", excluded])
+
             cmd.append(f"--timeout={SEMGREP_TIMEOUT}")
             cmd.append("--no-git-ignore")
             cmd.append("--json")
             cmd.append("--quiet")
             cmd.append("--disable-nosem")
             cmd.append(f"--max-target-bytes={SEMGREP_MAX_TARGET_BYTES}")
-            cmd.append(target)
+            cmd.extend(targets)
+
             log.debug(f"Invoking semgrep with command line: {' '.join(cmd)}")
             result = subprocess.run(
                 cmd, capture_output=True, check=True, encoding="utf-8"
@@ -367,7 +570,7 @@ output: {e.output}
             }
         """
 
-        results = defaultdict(list)
+        results: defaultdict[str, list[dict]] = defaultdict(list)
 
         for result in response["results"]:
             rule_name = rule or result["check_id"].split(".")[-1]
@@ -380,10 +583,8 @@ output: {e.output}
                     file_path=file_path, start_line=start_line, end_line=end_line
                 )
             )
-            if targetpath:
-                file_path = os.path.relpath(file_path, targetpath)
 
-            location = file_path + ":" + str(start_line)
+            location = os.path.basename(file_path) + ":" + str(start_line)
 
             finding = {
                 "location": location,
@@ -391,10 +592,8 @@ output: {e.output}
                 "message": result["extra"]["message"],
             }
 
-            rule_results = results[rule_name]
-            if finding in rule_results:
-                continue
-            results[rule_name].append(finding)
+            if finding not in results[rule_name]:
+                results[rule_name].append(finding)
 
         return results
 

--- a/guarddog/analyzer/sourcecode/code-execution.yml
+++ b/guarddog/analyzer/sourcecode/code-execution.yml
@@ -119,11 +119,6 @@ rules:
           metavariable: $ARG1
           patterns:
             - pattern-not-regex: (setup.py|twine|git|brew|gpg|freeze|docker|pycodestyle|libffi|coverage|pre_commit|pkg-config|cmake|pandoc|unittest|sys.executable)
-    paths:
-      include:
-        - "*/setup.py"
-        - "*/code-execution.py"
-        - "*/__init__.py"
     severity: WARNING
 
 


### PR DESCRIPTION
This attempts to fix issue #636 by recursively analyze local imports in PyPI packages. 

Previously, code-execution.yml used three hard-coded file paths. This commit removes those hardcoded paths and moves file discovery logic into analyzer.py.

The analyzer now:
- Starts from setup.py, code-execution.py, and __init__.py
- Recursively resolves local imports to discover all relevant source files
- Runs Semgrep rules only on those entrypoints and their resolved imports
- Warns when the depth of imports is very high (50), which may indicate suspicious package structure