### PR TITLE
fix: duplicate path in zip extraction

### DIFF
--- a/guarddog/utils/archives.py
+++ b/guarddog/utils/archives.py
@@ -74,6 +74,6 @@ def safe_extract(source_archive: str, target_directory: str) -> None:
                 # Note: zip.extract cleans up any malicious file name
                 # such as directory traversal attempts This is not the
                 # case of zipfile.extractall
-                zip.extract(file, path=os.path.join(target_directory, file))
+                zip.extract(file, path=target_directory)
     else:
         raise ValueError(f"unsupported archive extension: {source_archive}")


### PR DESCRIPTION
Fix duplicate path in ZIP extraction

`zip.extract()` already appends the [member filename](https://github.com/python/cpython/blob/12d363bb66b32b0e245ab7ab3c917ddf97a7e34d/Lib/zipfile/__init__.py#L1893) to the [targetpath](https://github.com/python/cpython/blob/12d363bb66b32b0e245ab7ab3c917ddf97a7e34d/Lib/zipfile/__init__.py#L1910).

This caused locations to appear as `pkg/file.py/pkg/file.py` instead of `pkg/file.py`.

Example extracted package:
```bash
$ ls -R validatekey-0.0.13-py3-none-any
validate key                 validatekey-0.0.13.dist-info

validatekey-0.0.13-py3-none-any/validate key:
__init__.py tools.py    utils.py

validatekey-0.0.13-py3-none-any/validatekey-0.0.13.dist-info:
LICENSE       METADATA      RECORD        WHEEL         top_level.txt
```
Running guarddog on this package yields the following with incorrect locations.
```json
    ...
    "shady-links": [
      {
        "location": "validate key/tools.py/validate key/tools.py:12",
        "code": "discordWebhook=str(\"https://discord.com/api/webhooks/...\")\n",
        "message": "This package contains an URL to a domain with a suspicious extension"
      },
      {
        "location": "validate key/utils.py/validate key/utils.py:17",
        "code": "        self.webhook = \"https://discord.com/api/webhooks/...\"\n",
        "message": "This package contains an URL to a domain with a suspicious extension"
      },
      {
        "location": "validate key/utils.py/validate key/utils.py:213",
        "code": "            r = requests.get(\"https://discord.com/api/v9/users/@me\", headers=self.getheaders(token))\n",
        "message": "This package contains an URL to a domain with a suspicious extension"
      },
      {
        "location": "validate key/utils.py/validate key/utils.py:218",
        "code": "                j = requests.get(\"https://discord.com/api/v9/users/@me\", headers=self.getheaders(token)).json()\n",
        "message": "This package contains an URL to a domain with a suspicious extension"
      },
      {
        "location": "validate key/utils.py/validate key/utils.py:270",
        "code": "            data = requests.get(\"http://ipinfo.io/json\").json()\n",
        "message": "This package contains an URL to a domain with a suspicious extension"
      }
    ],
    ...
```