### PR TITLE
Publish on tag workflow

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -67,7 +67,7 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git tag "v${{ steps.version-check.outputs.new_version }}"
-          git push origin "v${{ steps.version-check.outputs.new_version }}"
+          git push --tags
 
       - name: Create GitHub Release
         id: create-release
@@ -83,20 +83,71 @@ jobs:
       version_bumped: ${{ steps.version-check.outputs.version_bumped }}
       new_version: ${{ steps.version-check.outputs.new_version }}
 
-  pypi-release:
+  pypi-publish:
+    name: Build and Publish to PyPI
+    runs-on: ubuntu-latest
     needs: package-validation
     if: needs.package-validation.outputs.version_bumped == 'true'
-    uses: ./.github/workflows/pypi-publish.yml
-    secrets: inherit
     permissions:
       contents: read
-      id-token: write
 
-  docker-release:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          fetch-depth: 0
+
+      - name: 'Set up Python 3.10'
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: "3.10"
+          cache: 'pip'
+
+      - name: Install poetry
+        run: python -m pip install poetry --user
+
+      - name: Build
+        run: |
+          poetry version $(git describe --tags --abbrev=0)
+          poetry build
+
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+
+  docker-publish:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
     needs: package-validation
     if: needs.package-validation.outputs.version_bumped == 'true'
-    uses: ./.github/workflows/docker-publish.yml
-    secrets: inherit
     permissions:
       contents: read
       packages: write
+
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: datadog/guarddog
+
+    steps:
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            VERSION=${{ needs.package-validation.outputs.new_version }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.package-validation.outputs.new_version }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
This PR embeds pypi and docker publishing code into tag-release to solve the pypi trusted verifier limitation.