### PR TITLE
fix(go): remove signle-value LHS from taint sources in go-exfiltrate-sensitive-data

### DIFF
--- a/guarddog/analyzer/sourcecode/go-exfiltrate-sensitive-data.yml
+++ b/guarddog/analyzer/sourcecode/go-exfiltrate-sensitive-data.yml
@@ -17,7 +17,7 @@ rules:
           - patterns:
               - pattern-either:
                   - pattern: |
-                      $S = $OS.ReadFile($FILE)
+                      $OS.ReadFile($FILE)
                       ...
                   - patterns:
                       - pattern-either:
@@ -33,17 +33,17 @@ rules:
                           metavariable: $READCONENT
                           pattern-either:
                             - pattern: |
-                                $S = $IO.ReadAll($FILE)
+                                $IO.ReadAll($FILE)
                                 ...
                             - pattern: $S = $BUFIO.NewScanner($FILE)
                             - pattern: |
                                 $S = $BUFIO.NewReader($FILE)
                                 ...
                             - pattern: |
-                                $S = $F.Read($DATA)
+                                $F.Read($DATA)
                                 ...
                             - pattern: |
-                                $S = $F.ReadAll($FILE)
+                                $F.ReadAll($FILE)
                                 ...
               - metavariable-regex:
                   metavariable: $FILE


### PR DESCRIPTION
The go-exfiltrate-sensitive-data rule uses single-value assignment patterns as taint sources.

These patterns never match valid Go code. os.ReadFile, io.ReadAll, (*os.File).Read and ReadAll return multiple values (`([]byte, error)` or `(int, error)`).
In Go, the only valid syntax is a multi-value assignment: 

```go
data, err := os.ReadFile("")
data, _ := os.ReadFile("")
```

The rule produces zero findings on any malicious package using these functions, regardless of what is exfiltrated. 

I Removed the LHS from these patterns and replaced it with the style used in other Go rules in this repo. 

Closes #717 