### PR TITLE
Update chmod patterns to use octal notation

### DIFF
--- a/guarddog/analyzer/sourcecode/download-executable.yml
+++ b/guarddog/analyzer/sourcecode/download-executable.yml
@@ -56,12 +56,12 @@ rules:
                   metavariable: $MAKE_EXEC
                   pattern-either:
                     - pattern-either:
-                        - pattern: os.chmod("$LOC", 777)
-                        - pattern: os.chmod($LOC, 777)
+                        - pattern: os.chmod("$LOC", 0o777)
+                        - pattern: os.chmod($LOC, 0o777)
                         - pattern: os.chmod("$LOC", <...stat.S_IEXEC...>)
                         - pattern: os.chmod($LOC, <...stat.S_IEXEC...>)
-                        - pattern: chmod("$LOC", 777)
-                        - pattern: chmod($LOC, 777)
+                        - pattern: chmod("$LOC", 0o777)
+                        - pattern: chmod($LOC, 0o777)
                         - pattern: chmod("$LOC", <...stat.S_IEXEC...>)
                         - pattern: chmod($LOC, <...stat.S_IEXEC...>)
                         - pattern: os.system(f"...{$LOC}...")


### PR DESCRIPTION
Fix executable chmod patterns because 777 != 0o777 in Python.

TL;DR: I also gave a talk on that here: https://youtube.com/watch?t=35227&v=tRtxCCRdZOs

PS: It would be best if u checked your SAST rules with some kind of tests