### PR TITLE
feat: Add PyPI Inspector link for remote PyPI scans with issues

### DIFF
--- a/guarddog/cli.py
+++ b/guarddog/cli.py
@@ -218,6 +218,19 @@ def _scan(
         else:
             log.debug(f"Considering that '{identifier}' is a remote target")
             result |= scanner.scan_remote(identifier, version, rule_param)
+
+            scanned_version = version
+            if version is None and ecosystem == ECOSYSTEM.PYPI:
+                from guarddog.utils.package_info import get_package_info
+                try:
+                    package_info = get_package_info(identifier)
+                    scanned_version = package_info["info"]["version"]
+                except Exception:
+                    pass
+
+            result["is_remote"] = True
+            result["ecosystem"] = ecosystem
+            result["scanned_version"] = scanned_version
     except Exception as e:
         log.error(f"Error occurred while scanning target {identifier}: '{e}'\n")
         sys.exit(1)

--- a/guarddog/reporters/human_readable.py
+++ b/guarddog/reporters/human_readable.py
@@ -110,6 +110,16 @@ class HumanReadableReporter(BaseReporter):
                         )
                     lines.append("")
 
+        if (
+            num_issues > 0
+            and results.get("is_remote")
+            and results.get("ecosystem") == ECOSYSTEM.PYPI
+        ):
+            scanned_version = results.get("scanned_version")
+            if scanned_version:
+                inspector_url = f"https://inspector.pypi.io/project/{safe_identifier}/{scanned_version}"
+                lines.append(f"For more details, see: {inspector_url}")
+
         return "\n".join(lines)
 
     @staticmethod

--- a/tests/reporters/test_human_readable.py
+++ b/tests/reporters/test_human_readable.py
@@ -1,6 +1,7 @@
 import re
 
 from guarddog.reporters.human_readable import HumanReadableReporter, _sanitize
+from guarddog.ecosystems import ECOSYSTEM
 
 # Strips ANSI SGR/CSI/OSC sequences emitted by termcolor so assertions can match
 # the underlying text instead of color codes.
@@ -157,3 +158,78 @@ def test_print_scan_results_benign_input_is_preserved():
     assert "matched a benign-looking pattern" in plain
     assert "requests" in plain
     assert "rule-name" in plain
+
+
+def test_pypi_inspector_link_shown_for_remote_pypi_with_issues():
+    results = {
+        "issues": 1,
+        "errors": {},
+        "results": {
+            "some-rule": "found suspicious behavior"
+        },
+        "is_remote": True,
+        "ecosystem": ECOSYSTEM.PYPI,
+        "scanned_version": "2.28.1"
+    }
+    out = HumanReadableReporter.print_scan_results("requests", results)
+    plain = _strip_color(out)
+    assert "https://inspector.pypi.io/project/requests/2.28.1" in plain
+
+
+def test_pypi_inspector_link_not_shown_for_local_scan():
+    results = {
+        "issues": 1,
+        "errors": {},
+        "results": {
+            "some-rule": "found suspicious behavior"
+        }
+    }
+    out = HumanReadableReporter.print_scan_results("requests", results)
+    plain = _strip_color(out)
+    assert "inspector.pypi.io" not in plain
+
+
+def test_pypi_inspector_link_not_shown_when_no_issues():
+    results = {
+        "issues": 0,
+        "errors": {},
+        "results": {},
+        "is_remote": True,
+        "ecosystem": ECOSYSTEM.PYPI,
+        "scanned_version": "2.28.1"
+    }
+    out = HumanReadableReporter.print_scan_results("requests", results)
+    plain = _strip_color(out)
+    assert "inspector.pypi.io" not in plain
+
+
+def test_pypi_inspector_link_not_shown_for_npm():
+    results = {
+        "issues": 1,
+        "errors": {},
+        "results": {
+            "some-rule": "found suspicious behavior"
+        },
+        "is_remote": True,
+        "ecosystem": ECOSYSTEM.NPM,
+        "scanned_version": "1.0.0"
+    }
+    out = HumanReadableReporter.print_scan_results("lodash", results)
+    plain = _strip_color(out)
+    assert "inspector.pypi.io" not in plain
+
+
+def test_pypi_inspector_link_not_shown_when_version_is_none():
+    results = {
+        "issues": 1,
+        "errors": {},
+        "results": {
+            "some-rule": "found suspicious behavior"
+        },
+        "is_remote": True,
+        "ecosystem": ECOSYSTEM.PYPI,
+        "scanned_version": None
+    }
+    out = HumanReadableReporter.print_scan_results("requests", results)
+    plain = _strip_color(out)
+    assert "inspector.pypi.io" not in plain


### PR DESCRIPTION
## Description

This PR implements the feature requested in #67.

When scanning a remote PyPI package and issues are found, GuardDog now displays a link to PyPI Inspector for easier investigation.

## Changes

- **cli.py**: Added `is_remote`, `ecosystem`, and `scanned_version` fields to scan results for remote scans
- **human_readable.py**: Display PyPI Inspector link when:
  - Scanning a remote PyPI package (not local files)
  - At least one issue is found
  - Version information is available
- **test_human_readable.py**: Added 5 test cases to verify:
  - Link is shown for remote PyPI scans with issues
  - Link is NOT shown for local scans
  - Link is NOT shown when no issues found
  - Link is NOT shown for other ecosystems (npm, etc.)
  - Link is NOT shown when version is None

## Example Output

```
Found 2 potentially malicious indicators in requests

some-rule: found suspicious behavior

For more details, see: https://inspector.pypi.io/project/requests/2.28.1
```

## Testing

All new tests pass. The implementation follows the existing code style and patterns.

Fixes #67