### PR TITLE
Fix tag release on bump

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -17,16 +17,23 @@ jobs:
     runs-on: ubuntu-latest
     needs: run-checks
     permissions:
-      contents: write
+      contents: read
+      id-token: write
 
     steps:
       - uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: audit
+      - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        id: octo-sts
+        with:
+          scope: DataDog/guarddog
+          policy: self.github.tag-release.main
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
+          token: ${{ steps.octo-sts.outputs.token }}
 
       - name: 'Set up Python 3.10'
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
@@ -77,7 +84,7 @@ jobs:
         id: create-release
         if: steps.version-check.outputs.version_bumped == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: |
           gh release create "v${{ steps.version-check.outputs.new_version }}" \
             --title "Release v${{ steps.version-check.outputs.new_version }}" \


### PR DESCRIPTION
This PR uses dd-octo-sts to create a tag and release when a bump to the package version is issued