### PR TITLE
Guarddog v3 announcement

### DIFF
--- a/.github/chainguard/self.github.tag-release.v3.sts.yaml
+++ b/.github/chainguard/self.github.tag-release.v3.sts.yaml
@@ -1,0 +1,12 @@
+# Policy for: .github/workflows/tag-release.yml (job: package-validation) in DataDog/guarddog
+issuer: https://token.actions.githubusercontent.com
+subject: repo:DataDog/guarddog:ref:refs/heads/v3
+
+claim_pattern:
+  event_name: (push|workflow_dispatch)
+  job_workflow_ref: DataDog/guarddog/\.github/workflows/tag-release\.yml@refs/heads/v3
+  ref: refs/heads/v3
+  repository: DataDog/guarddog
+
+permissions:
+  contents: write

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -45,4 +45,4 @@ jobs:
             VERSION=${{ github.ref_name }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ startsWith(github.ref_name, 'v2.') && format('{0}/{1}:latest', env.REGISTRY, env.IMAGE_NAME) || '' }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - v3
 
 permissions:
   contents: read

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    branches: [main, v3]
   workflow_dispatch:
 
 permissions:
@@ -28,7 +28,7 @@ jobs:
         id: octo-sts
         with:
           scope: DataDog/guarddog
-          policy: self.github.tag-release.main
+          policy: self.github.tag-release.${{ github.ref_name }}
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
@@ -168,4 +168,4 @@ jobs:
             VERSION=${{ needs.package-validation.outputs.new_version }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.package-validation.outputs.new_version }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ github.ref_name == 'main' && format('{0}/{1}:latest', env.REGISTRY, env.IMAGE_NAME) || '' }}

--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@
   <img src="https://github.com/DataDog/guarddog/blob/main/docs/images/logo.png?raw=true" alt="GuardDog" width="300" />
 </p>
 
+<p align="center">
+  <a href="https://github.com/DataDog/guarddog/tree/v3">
+    <img src="docs/images/v3-banner.svg" alt="GuardDog v3 is here — Explore the v3 branch" width="800" />
+  </a>
+</p>
+
+
 GuardDog is a CLI tool that allows to identify malicious PyPI and npm packages, Go modules, RubyGems, GitHub actions, or VSCode extensions. It runs a set of heuristics on the package source code (through Semgrep rules) and on the package metadata.
 
 GuardDog can be used to scan local or remote PyPI and npm packages, Go modules, RubyGems, GitHub actions, or VSCode extensions using any of the available [heuristics](#heuristics).

--- a/docs/images/v3-banner.svg
+++ b/docs/images/v3-banner.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 340" role="img" aria-label="GuardDog v3 is here. Explore the v3 branch.">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#632CA6"/>
+      <stop offset="100%" stop-color="#4A1F80"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1200" height="340" rx="16" ry="16" fill="url(#bg)"/>
+
+  <text x="600" y="78" text-anchor="middle"
+        font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="16" font-weight="700" fill="#E4D5F5" letter-spacing="3">
+    📣 ANNOUNCEMENT
+  </text>
+
+  <text x="600" y="150" text-anchor="middle"
+        font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="46" font-weight="700" fill="#ffffff">
+    GuardDog v3 is here
+  </text>
+
+  <text x="600" y="200" text-anchor="middle"
+        font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="20" fill="#E4D5F5">
+    Better 🔥 Faster ⚡ Stronger 💪
+  </text>
+
+  <g transform="translate(450, 245)">
+    <rect width="300" height="56" rx="10" ry="10" fill="#ffffff"/>
+    <text x="150" y="36" text-anchor="middle"
+          font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+          font-size="17" font-weight="600" fill="#632CA6">
+      Explore the v3 branch →
+    </text>
+  </g>
+</svg>


### PR DESCRIPTION
# Summary
  - Add README banner announcing the upcoming v3 preview
  - Register `self.github.tag-release.v3` dd-octo-sts policy
  - Make release/CI workflows branch-agnostic so v3 inherits identical CI from main via sync — no per-branch maintenance

  ## What changes
  - `tag-release.yml` — triggers on `[main, v3]`; octo-sts policy is now `self.github.tag-release.${{ github.ref_name }}`; `:latest` Docker tag is only pushed when running from `main`
  - `docker-publish.yml` (manual failsafe path) — `:latest` only for `v2.*` tags
  - `pr.yml` — runs checks on PRs into `main` or `v3`

  ## What doesn't change
  Main's existing release flow: pushes to main still trigger `tag-release`, still publish `:latest`, still use the `.main` policy. No artifacts are published by this PR.
