### PR TITLE
Add writing-guarddog-rules Claude skill

### DIFF
--- a/.claude/skills/writing-guarddog-rules/SKILL.md
+++ b/.claude/skills/writing-guarddog-rules/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-guarddog-rules
-description: Author, edit, and review GuardDog source-code detection rules (YARA .yar / Semgrep .yml) that follow the capability/threat/risk model. Use when adding a new detection rule, changing an existing rule's patterns or metadata, splitting capabilities from threats, debugging false positives, or writing rule test cases under guarddog/analyzer/sourcecode/.
+description: Author, edit, and review GuardDog YARA source-code detection rules (.yar) that follow the capability/threat/risk model. Use when adding a new detection rule, changing an existing rule's patterns or metadata, splitting capabilities from threats, debugging false positives, or writing rule test cases under guarddog/analyzer/sourcecode/.
 ---
 
 # Writing GuardDog Rules
@@ -36,20 +36,20 @@ or a *suspicious indicator* (threat)? Does it stand alone without a capability (
 
 1. **Decide type and category.** Pick `capability` vs `threat`, then category and optional detail.
    Confirm the matching counterpart exists or will exist so a risk can form.
-2. **Pick the format.** YARA (`.yar`) for cross-language byte/regex/string patterns and obfuscation;
-   Semgrep (`.yml`) for AST-aware, language-specific code structure. YARA rules load for all
-   ecosystems; Semgrep rules load only when the language matches the ecosystem.
-3. **Write patterns** following the best practices in `WRITING_RULES.md` (word boundaries `\b`,
+2. **Write patterns** as YARA (`.yar`). Source-code rules are YARA-only and language-agnostic
+   (loaded for every ecosystem). Note that `WRITING_RULES.md` still shows a Semgrep `.yml` example;
+   that path no longer exists in this codebase, so ignore it and write YARA. Follow the best
+   practices in `WRITING_RULES.md` (word boundaries `\b`,
    match method calls not object names, require quote context for bare strings, establish context
    with private rules before matching threats). Extract shared building blocks (LOLBAS, hooks) into
    `.meta` files instead of repeating them.
-4. **Add metadata.** Required: `identifies`, `severity`, `description`. Threat rules also need a
-   single `mitre_tactics`. Optional `specificity`/`sophistication` default to `medium`. YARA-only:
-   `max_hits`, `path_include`. See the schema section of `WRITING_RULES.md`.
-5. **Name and place the file** under `guarddog/analyzer/sourcecode/` as `{type}-{category}-{detail}.yar`
-   (or `.yml`). `.meta` files are `{pattern-name}.meta`.
-6. **Write test cases** (see below).
-7. **Run the checklist** at the end of `WRITING_RULES.md` before finishing.
+3. **Add metadata.** Required: `identifies`, `severity`, `description`. Threat rules also need a
+   single `mitre_tactics`. Optional `specificity`/`sophistication` default to `medium`. Also
+   available: `max_hits`, `path_include`. See the schema section of `WRITING_RULES.md`.
+4. **Name and place the file** under `guarddog/analyzer/sourcecode/` as `{type}-{category}-{detail}.yar`.
+   `.meta` files (shared private rules) are `{pattern-name}.meta`.
+5. **Write test cases** (see below).
+6. **Run the checklist** at the end of `WRITING_RULES.md` before finishing.
 
 ## Testing rules (the real harness)
 

--- a/.claude/skills/writing-guarddog-rules/SKILL.md
+++ b/.claude/skills/writing-guarddog-rules/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: writing-guarddog-rules
+description: Author, edit, and review GuardDog source-code detection rules (YARA .yar / Semgrep .yml) that follow the capability/threat/risk model. Use when adding a new detection rule, changing an existing rule's patterns or metadata, splitting capabilities from threats, debugging false positives, or writing rule test cases under guarddog/analyzer/sourcecode/.
+---
+
+# Writing GuardDog Rules
+
+GuardDog detects supply-chain malware with a two-layer model. The full reference,
+including the philosophy, metadata schema, and worked examples, lives in
+**`WRITING_RULES.md` at the repository root** (the skill directory is
+`.claude/skills/writing-guarddog-rules/`, so the doc is three levels up). This
+skill is the procedural layer: it captures the mental model and the workflow,
+and it points to the reference for detail. Read `WRITING_RULES.md` when you need
+the schema specifics, field definitions, or longer examples; do not duplicate it.
+
+## The model (memorize this, skip the doc for simple calls)
+
+- **Capability = "CAN DO"** — a function call that enables an action
+  (`requests.get(`, `.readFileSync(`, `subprocess.Popen(`). Match calls, not imports.
+- **Threat = "SUSPICIOUS"** — an attacker indicator (`/etc/passwd`, `discord.com/api/webhooks`,
+  `base64.decode` + `exec` together). Not a bare function call.
+- **Risk = capability + threat in the same file with matching category.** A capability
+  alone is benign; a threat indicator alone is often a false positive; together they are a risk.
+- **`identifies` format:** `{type}.{category}[.{detail}]` where type is `capability` or `threat`,
+  category is one of `network`, `filesystem`, `process`, `runtime`, `system`, `metadata`.
+- **Categories must match** for a risk to form. `capability.process.*` only pairs with
+  `threat.process.*`. General detail matches specific (`threat.network` + `capability.network.outbound`),
+  but conflicting details do not (`...outbound` + `...inbound`).
+- **`threat.runtime.*` and `threat.metadata.*` auto-form risks** without needing a capability
+  (obfuscation, install hooks, typosquatting, maintainer compromise).
+
+When unsure whether a pattern is a capability or threat: does it show what code *can do* (capability)
+or a *suspicious indicator* (threat)? Does it stand alone without a capability (runtime/metadata threat)?
+
+## Authoring workflow
+
+1. **Decide type and category.** Pick `capability` vs `threat`, then category and optional detail.
+   Confirm the matching counterpart exists or will exist so a risk can form.
+2. **Pick the format.** YARA (`.yar`) for cross-language byte/regex/string patterns and obfuscation;
+   Semgrep (`.yml`) for AST-aware, language-specific code structure. YARA rules load for all
+   ecosystems; Semgrep rules load only when the language matches the ecosystem.
+3. **Write patterns** following the best practices in `WRITING_RULES.md` (word boundaries `\b`,
+   match method calls not object names, require quote context for bare strings, establish context
+   with private rules before matching threats). Extract shared building blocks (LOLBAS, hooks) into
+   `.meta` files instead of repeating them.
+4. **Add metadata.** Required: `identifies`, `severity`, `description`. Threat rules also need a
+   single `mitre_tactics`. Optional `specificity`/`sophistication` default to `medium`. YARA-only:
+   `max_hits`, `path_include`. See the schema section of `WRITING_RULES.md`.
+5. **Name and place the file** under `guarddog/analyzer/sourcecode/` as `{type}-{category}-{detail}.yar`
+   (or `.yml`). `.meta` files are `{pattern-name}.meta`.
+6. **Write test cases** (see below).
+7. **Run the checklist** at the end of `WRITING_RULES.md` before finishing.
+
+## Testing rules (the real harness)
+
+The testing section of `WRITING_RULES.md` is out of date for YARA. Use the actual harness in
+`tests/analyzer/sourcecode/test_sourcecode_yara.py`:
+
+- **The YARA rule's internal name must be the file id with hyphens replaced by underscores.**
+  File `capability-filesystem-read.yar` must contain `rule capability_filesystem_read`. The
+  no-false-positive test filters matches to this exact name, so a mismatch silently skips coverage.
+- **Positive test:** add a file `tests/analyzer/sourcecode/<rule-id>.<ext>` containing code the rule
+  should flag (e.g. `<rule-id>.py`, `.js`, `.go`, `.rb`). The harness asserts the rule matches it.
+  These are matched by filename prefix, not by `# ruleid:` comments.
+- **Negative test (false positives):** add `tests/analyzer/sourcecode/benign/<rule-id>.<ext>` with
+  legitimate code that must NOT trigger the main rule. Every new or changed rule should have one.
+- **Compilation:** all `.yar` files must compile, including `include "...meta"` references resolving.
+
+Run the suite:
+
+```bash
+make test-yara-rules
+# or directly:
+uv run pytest tests/analyzer/sourcecode -k <rule-id>
+```
+
+Scan a real package or local path to sanity-check end to end (use `uv run`):
+
+```bash
+uv run guarddog pypi scan <package-name> --rules <rule-id>
+uv run guarddog pypi scan /path/to/package --output-format json
+```
+
+## Common patterns and pitfalls
+
+- **Install hooks are a capability, not a threat.** A hook is process-spawning ability like
+  `subprocess.call()`. The threat is the LOLBAS tool *inside* the hook. Pair
+  `capability.process.hooks` with `threat.process.hooks` (hook context + curl/wget). See the
+  Advanced Patterns section of `WRITING_RULES.md`.
+- **Split LOLBAS by purpose:** `lolbas-proc.meta` (bash, python, node) vs `lolbas-net.meta`
+  (curl, wget, nc). YARA cannot reliably use multiple private rules from one include, so keep
+  them separate and compose includes per rule.
+- **Avoid false positives from shebangs, READMEs, and non-hook code** by establishing context
+  with private rules rather than matching a bare keyword anywhere.
+- After adding or editing rules, regenerate docs if the repo expects it: `make docs`.

--- a/.claude/skills/writing-guarddog-rules/SKILL.md
+++ b/.claude/skills/writing-guarddog-rules/SKILL.md
@@ -37,9 +37,7 @@ or a *suspicious indicator* (threat)? Does it stand alone without a capability (
 1. **Decide type and category.** Pick `capability` vs `threat`, then category and optional detail.
    Confirm the matching counterpart exists or will exist so a risk can form.
 2. **Write patterns** as YARA (`.yar`). Source-code rules are YARA-only and language-agnostic
-   (loaded for every ecosystem). Note that `WRITING_RULES.md` still shows a Semgrep `.yml` example;
-   that path no longer exists in this codebase, so ignore it and write YARA. Follow the best
-   practices in `WRITING_RULES.md` (word boundaries `\b`,
+   (loaded for every ecosystem). Follow the best practices in `WRITING_RULES.md` (word boundaries `\b`,
    match method calls not object names, require quote context for bare strings, establish context
    with private rules before matching threats). Extract shared building blocks (LOLBAS, hooks) into
    `.meta` files instead of repeating them.
@@ -53,15 +51,14 @@ or a *suspicious indicator* (threat)? Does it stand alone without a capability (
 
 ## Testing rules (the real harness)
 
-The testing section of `WRITING_RULES.md` is out of date for YARA. Use the actual harness in
-`tests/analyzer/sourcecode/test_sourcecode_yara.py`:
+The harness is `tests/analyzer/sourcecode/test_sourcecode_yara.py`. Key points:
 
 - **The YARA rule's internal name must be the file id with hyphens replaced by underscores.**
   File `capability-filesystem-read.yar` must contain `rule capability_filesystem_read`. The
   no-false-positive test filters matches to this exact name, so a mismatch silently skips coverage.
 - **Positive test:** add a file `tests/analyzer/sourcecode/<rule-id>.<ext>` containing code the rule
   should flag (e.g. `<rule-id>.py`, `.js`, `.go`, `.rb`). The harness asserts the rule matches it.
-  These are matched by filename prefix, not by `# ruleid:` comments.
+  These are matched by filename prefix.
 - **Negative test (false positives):** add `tests/analyzer/sourcecode/benign/<rule-id>.<ext>` with
   legitimate code that must NOT trigger the main rule. Every new or changed rule should have one.
 - **Compilation:** all `.yar` files must compile, including `include "...meta"` references resolving.

--- a/WRITING_RULES.md
+++ b/WRITING_RULES.md
@@ -271,27 +271,6 @@ rule threat_filesystem_read
 }
 ```
 
-### Semgrep Rule Example
-
-```yaml
-rules:
-  - id: threat-network-suspicious-domain
-    languages:
-      - python
-      - javascript
-    message: Detects connection to suspicious domain
-    metadata:
-      identifies: "threat.network.outbound"
-      severity: "high"
-      mitre_tactics: "exfiltration"
-      specificity: "high"
-      sophistication: "low"
-      description: "Detects URLs to suspicious domains used for exfiltration"
-    patterns:
-      - pattern-regex: '(pastebin\.com|transfer\.sh|discord\.com/api/webhooks)'
-    severity: WARNING
-```
-
 ## Pattern Writing Best Practices
 
 ### 1. Use Word Boundaries
@@ -413,54 +392,69 @@ rule threat_process_hooks
 
 ### Unit Testing
 
-Create test files in `tests/analyzer/sourcecode/` following this structure:
+The YARA test harness lives in `tests/analyzer/sourcecode/test_sourcecode_yara.py`. It does three
+things for every rule: compiles it, asserts it matches each positive test file, and asserts it does
+**not** match the benign files. Tests are matched to a rule **by filename prefix**, so test files are
+flat (no per-rule subdirectory) and named after the rule id.
+
+**The YARA rule's internal name must be the rule id with hyphens replaced by underscores.** The
+no-false-positive check filters matches to that exact name, so a mismatch silently drops coverage:
+
+```yara
+// file: capability-network-outbound.yar
+rule capability_network_outbound { ... }
+```
+
+**Positive tests** — add one file per language the rule should flag. The harness asserts the rule
+matches it:
 
 ```
 tests/analyzer/sourcecode/
-  ruleset_test_<rule-id>/
-    <rule-id>.py        # Test case for Python
-    <rule-id>.js        # Test case for JavaScript
-    <rule-id>.go        # Test case for Go
+  capability-network-outbound.py    # requests.get("https://example.com")
+  capability-network-outbound.js    # fetch("https://example.com")
+  capability-network-outbound.go    # http.Get("https://example.com")
 ```
 
-Test file should contain patterns that **should** and **should not** match:
+**Negative tests** — add legitimate code that must NOT trigger the rule under `benign/`. Every new
+or changed rule should have one to lock in against false positives:
 
-```python
-# tests/analyzer/sourcecode/ruleset_test_capability-network-outbound/capability-network-outbound.py
+```
+tests/analyzer/sourcecode/benign/
+  capability-network-outbound.py    # import requests   (declared but never called)
+```
 
-# ruleid: capability-network-outbound
-import requests
-requests.get("https://example.com")
+Run the suite:
 
-# ok: capability-network-outbound
-# Just importing shouldn't match
-import requests
+```bash
+make test-yara-rules
+# or just one rule:
+uv run pytest tests/analyzer/sourcecode -k capability-network-outbound
 ```
 
 ### Manual Testing
 
 ```bash
 # Test on a specific package
-guarddog pypi scan package-name --rules my-rule
+uv run guarddog pypi scan package-name --rules my-rule
 
 # Test with specific rules only
-guarddog pypi scan package-name --rules rule1 --rules rule2
+uv run guarddog pypi scan package-name --rules rule1 --rules rule2
 
 # Exclude specific rules
-guarddog pypi scan package-name --exclude-rules my-rule
+uv run guarddog pypi scan package-name --exclude-rules my-rule
 
 # Test on local directory
-guarddog pypi scan /path/to/package/
+uv run guarddog pypi scan /path/to/package/
 
 # Output JSON for analysis
-guarddog pypi scan package-name --output-format json
+uv run guarddog pypi scan package-name --output-format json
 ```
 
 ### Validation Checklist
 
 Before submitting a rule:
 
-- [ ] Rule filename matches rule ID
+- [ ] Rule filename matches rule ID, and the YARA `rule` name is the id with hyphens as underscores
 - [ ] `identifies` field follows `{type}.{category}[.{detail}]` format
 - [ ] Category is one of: `network`, `filesystem`, `process`, `runtime`, `system`
 - [ ] Category matches between capability and threat (for risk formation)
@@ -474,7 +468,7 @@ Before submitting a rule:
 - [ ] Duplicated patterns extracted to `.meta` files
 - [ ] Include paths are correct and `.meta` files exist
 - [ ] Private rules cannot be used together from same file (split if needed)
-- [ ] Test cases created with positive and negative examples
+- [ ] Positive test file(s) added under `tests/analyzer/sourcecode/` and a `benign/` negative test
 - [ ] Rule tested manually on real packages
 - [ ] Verified no false positives from shebangs, READMEs, or non-hook code
 
@@ -577,23 +571,16 @@ rule lolbas_net
 
 Use word boundaries (`\b`) to avoid false positives from substring matches.
 
-## Support Formats
+## Rule Format
 
-GuardDog supports two rule formats:
+Source-code rules are written in YARA (`.yar`):
 
-### YARA Rules (`.yar`)
-- **Language-agnostic**: All YARA rules are loaded regardless of ecosystem
-- **Binary-safe**: Can scan any file type
-- **Pattern matching**: Great for byte patterns, strings, regex
-- **Best for**: Cross-language patterns, obfuscation detection, binary analysis
+- **Language-agnostic**: every YARA rule is loaded regardless of ecosystem
+- **Binary-safe**: can scan any file type
+- **Pattern matching**: great for byte patterns, strings, and regex
+- **Best for**: cross-language patterns, obfuscation detection, binary analysis
 
-### Semgrep Rules (`.yml`)
-- **Language-aware**: Only loaded when language matches ecosystem
-- **AST-based**: Understands code structure
-- **Metavariables**: Can match and reuse code fragments
-- **Best for**: Complex code patterns, language-specific detection
-
-Choose YARA for broad pattern matching across all files. Choose Semgrep for language-specific code analysis.
+Shared private rules go in `.meta` files (see the DRY section above).
 
 ## File Organization
 


### PR DESCRIPTION
## What

1. Adds a Claude skill at `.claude/skills/writing-guarddog-rules/SKILL.md` that guides authoring, editing, and reviewing GuardDog YARA detection rules.
2. Updates `WRITING_RULES.md` to drop Semgrep and fix the testing docs.

## The skill: a lean layer over WRITING_RULES.md

`WRITING_RULES.md` (linked from the README) stays the single source of truth for the full philosophy, metadata schema, and worked examples. The skill is a thin procedural layer over it:

- Captures the capability / threat / risk mental model so simple decisions don't require opening the doc.
- Lays out the authoring workflow (decide type/category, write YARA patterns, add metadata, name/place the file, test, run the checklist).
- Points to the relevant sections of `WRITING_RULES.md` rather than copying its content.

## WRITING_RULES.md cleanup

While building the skill I found the doc was stale in two ways, both fixed here:

- **Semgrep is gone in v3.** Source-code rules are YARA-only (no `.yml` rules, no `semgrep` in the code, only a `YaraRule` class). Removed the Semgrep rule example and the two-formats section.
- **The testing section was wrong for YARA.** It described `ruleset_test_*/` directories and Semgrep-style `# ruleid:` / `# ok:` annotations. Rewrote it to match the real harness in `tests/analyzer/sourcecode/test_sourcecode_yara.py`:
  - Positive tests are flat files `tests/analyzer/sourcecode/<rule-id>.<ext>`, matched by filename prefix.
  - Negative tests live in `tests/analyzer/sourcecode/benign/<rule-id>.<ext>`.
  - A YARA rule's internal name must be the file id with hyphens replaced by underscores, or the no-false-positive check silently skips it.
  - Manual-testing commands now use `uv run`.