### PR TITLE
Fix v3 evals

### DIFF
--- a/evals/benchmark.py
+++ b/evals/benchmark.py
@@ -15,7 +15,6 @@ import argparse
 import concurrent.futures
 import json
 import os
-import shutil
 import subprocess
 import sys
 import time
@@ -41,17 +40,14 @@ def parse_args():
     p.add_argument("--workers", type=int, default=20)
     p.add_argument("--timeout", type=int, default=300)
     p.add_argument("--force-fetch", action="store_true")
-    p.add_argument("--guarddog-bin", default=None, help="Path to guarddog binary")
+    p.add_argument("--guarddog-bin", default=None, help="Path to guarddog binary (default: uv run guarddog)")
     return p.parse_args()
 
 
-def find_guarddog_bin(override: str | None) -> str:
+def find_guarddog_cmd(override: str | None) -> list[str]:
     if override:
-        return override
-    found = shutil.which("guarddog")
-    if found:
-        return found
-    sys.exit("ERROR: guarddog not found on PATH. Install it or pass --guarddog-bin")
+        return [override]
+    return ["uv", "run", "guarddog"]
 
 
 # ---------------------------------------------------------------------------
@@ -110,7 +106,7 @@ def sanitize_filename(name: str) -> str:
     return name.replace("@", "_at_").replace("/", "__")
 
 
-def scan_package(package: str, ecosystem: str, gd_bin: str,
+def scan_package(package: str, ecosystem: str, gd_cmd: list[str],
                  results_dir: Path, timeout: int) -> dict:
     safe = sanitize_filename(package)
     out_dir = results_dir / ecosystem
@@ -123,7 +119,7 @@ def scan_package(package: str, ecosystem: str, gd_bin: str,
     result = {"package": package, "ecosystem": ecosystem,
               "scan_time": None, "error": None, "output": None}
 
-    cmd = [gd_bin, ecosystem, "scan", package, "--output-format", "json"]
+    cmd = [*gd_cmd, ecosystem, "scan", package, "--output-format", "json"]
     start = time.time()
     try:
         proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
@@ -146,7 +142,7 @@ def scan_package(package: str, ecosystem: str, gd_bin: str,
     return result
 
 
-def run_scan(work_dir: Path, ecosystems: list[str], gd_bin: str,
+def run_scan(work_dir: Path, ecosystems: list[str], gd_cmd: list[str],
              workers: int, timeout: int):
     results_dir = work_dir / "results"
 
@@ -169,7 +165,7 @@ def run_scan(work_dir: Path, ecosystems: list[str], gd_bin: str,
     with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
         futures = {}
         for name, eco in tasks:
-            fut = executor.submit(scan_package, name, eco, gd_bin, results_dir, timeout)
+            fut = executor.submit(scan_package, name, eco, gd_cmd, results_dir, timeout)
             futures[fut] = (name, eco)
 
         for fut in concurrent.futures.as_completed(futures):
@@ -483,9 +479,9 @@ def main():
     if phase in ("all", "fetch"):
         run_fetch(work_dir, args.ecosystems, args.max_packages, args.force_fetch)
     if phase in ("all", "scan"):
-        gd_bin = find_guarddog_bin(args.guarddog_bin)
-        print(f"Using guarddog: {gd_bin}")
-        run_scan(work_dir, args.ecosystems, gd_bin, args.workers, args.timeout)
+        gd_cmd = find_guarddog_cmd(args.guarddog_bin)
+        print(f"Using guarddog: {' '.join(gd_cmd)}")
+        run_scan(work_dir, args.ecosystems, gd_cmd, args.workers, args.timeout)
     if phase in ("all", "report"):
         run_report(work_dir, args.ecosystems)
 

--- a/evals/recall_worker.py
+++ b/evals/recall_worker.py
@@ -42,8 +42,8 @@ def setup_sandbox(tmp_dir: str, zip_path: str, output_path: str, guarddog_bin: s
 
     caps = nono.CapabilitySet()
     caps.allow_path(tmp_dir, nono.AccessMode.READ_WRITE)
-    caps.allow_path(zip_path, nono.AccessMode.READ)
-    caps.allow_path(output_path, nono.AccessMode.READ_WRITE)
+    caps.allow_file(zip_path, nono.AccessMode.READ)
+    caps.allow_file(output_path, nono.AccessMode.READ_WRITE)
 
     # Allow Python runtime + site-packages (guarddog, semgrep, yara, etc.)
     python_prefix = os.path.realpath(sys.prefix)
@@ -61,19 +61,13 @@ def setup_sandbox(tmp_dir: str, zip_path: str, output_path: str, guarddog_bin: s
 
     caps.block_network()
 
-    # Dry-run validation
+    # Dry-run validation (only for directory paths; allow_file paths can't be query_path'd)
     ctx = nono.QueryContext(caps)
-    checks = [
-        (tmp_dir, nono.AccessMode.READ_WRITE, "tmp_dir"),
-        (zip_path, nono.AccessMode.READ, "zip_path"),
-        (output_path, nono.AccessMode.READ_WRITE, "output_path"),
-    ]
-    for path, mode, label in checks:
-        result = ctx.query_path(path, mode)
-        status = result.get("status") if isinstance(result, dict) else getattr(result, "status", None)
-        if status == "denied":
-            print(f"ERROR: sandbox validation failed for {label} ({path})", file=sys.stderr)
-            sys.exit(1)
+    result = ctx.query_path(tmp_dir, nono.AccessMode.READ_WRITE)
+    status = result.get("status") if isinstance(result, dict) else getattr(result, "status", None)
+    if status == "denied":
+        print(f"ERROR: sandbox validation failed for tmp_dir ({tmp_dir})", file=sys.stderr)
+        sys.exit(1)
 
     nono.apply(caps)
 
@@ -125,7 +119,8 @@ def scan_package(extracted_dir: str, ecosystem: str, guarddog_bin: str | None = 
     if not guarddog_bin:
         return {"results": {}, "error": "guarddog not found on PATH"}
 
-    cmd = [guarddog_bin, ecosystem, "scan", extracted_dir, "--output-format", "json"]
+    # --no-sandbox: this worker is already sandboxed by nono; nono cannot be nested
+    cmd = [guarddog_bin, ecosystem, "scan", extracted_dir, "--output-format", "json", "--no-sandbox"]
 
     # Pass metadata file if available (enables metadata rules for local scans)
     metadata_file = find_metadata_file(extracted_dir)

--- a/evals/recall_worker.py
+++ b/evals/recall_worker.py
@@ -119,7 +119,7 @@ def scan_package(extracted_dir: str, ecosystem: str, guarddog_bin: str | None = 
     if not guarddog_bin:
         return {"results": {}, "error": "guarddog not found on PATH"}
 
-    # --no-sandbox: this worker is already sandboxed by nono; nono cannot be nested
+    # --no-sandbox: the worker process is already sandboxed; guarddog must not apply a second sandbox
     cmd = [guarddog_bin, ecosystem, "scan", extracted_dir, "--output-format", "json", "--no-sandbox"]
 
     # Pass metadata file if available (enables metadata rules for local scans)

--- a/evals/recall_worker.py
+++ b/evals/recall_worker.py
@@ -49,10 +49,21 @@ def setup_sandbox(tmp_dir: str, zip_path: str, output_path: str, guarddog_bin: s
     python_prefix = os.path.realpath(sys.prefix)
     caps.allow_path(python_prefix, nono.AccessMode.READ)
 
-    # Also allow the real base prefix (for system Python libs)
+    # Allow the base prefix (for system Python libs). Use both realpath and the
+    # raw path because the sandbox checks raw paths without resolving symlinks —
+    # uv installs Python under a versioned dir (cpython-3.12.8-...) but exposes
+    # a symlink (cpython-3.12-...) and Python loads stdlib via the symlink path.
     base_prefix = os.path.realpath(sys.base_prefix)
     if base_prefix != python_prefix:
         caps.allow_path(base_prefix, nono.AccessMode.READ)
+    stdlib_dir = os.path.dirname(os.__file__)
+    if not stdlib_dir.startswith(base_prefix) and not stdlib_dir.startswith(python_prefix):
+        caps.allow_path(stdlib_dir, nono.AccessMode.READ)
+
+    # Allow guarddog source tree (installed as editable via .pth, so the source
+    # dir is separate from the venv and must be explicitly allowed)
+    project_root = os.path.realpath(os.path.join(os.path.dirname(__file__), ".."))
+    caps.allow_path(project_root, nono.AccessMode.READ)
 
     # Allow guarddog binary and its directory (for subprocess execution)
     if guarddog_bin:

--- a/evals/recall_worker.py
+++ b/evals/recall_worker.py
@@ -120,7 +120,7 @@ def scan_package(extracted_dir: str, ecosystem: str, guarddog_bin: str | None = 
         return {"results": {}, "error": "guarddog not found on PATH"}
 
     # --no-sandbox: the worker process is already sandboxed; guarddog must not apply a second sandbox
-    cmd = [guarddog_bin, ecosystem, "scan", extracted_dir, "--output-format", "json", "--no-sandbox"]
+    cmd = [guarddog_bin, ecosystem, "scan", "--no-sandbox", "--output-format", "json", extracted_dir]
 
     # Pass metadata file if available (enables metadata rules for local scans)
     metadata_file = find_metadata_file(extracted_dir)

--- a/guarddog/scanners/github_action_project_scanner.py
+++ b/guarddog/scanners/github_action_project_scanner.py
@@ -1,7 +1,12 @@
 import logging
 import os
+import sys
 from typing import List, Dict, TypedDict
-from typing_extensions import NotRequired
+
+if sys.version_info >= (3, 11):
+    from typing import NotRequired
+else:
+    from typing_extensions import NotRequired
 
 import yaml
 import re

--- a/poetry.lock
+++ b/poetry.lock
@@ -1677,7 +1677,7 @@ version = "26.2"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"},
     {file = "packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"},
@@ -2468,4 +2468,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4"
-content-hash = "524ea887c25545c539552b09d644705f3a5592dee09863177ac3992f2c813e34"
+content-hash = "f7d6d6b2a1c3878e413d781f9f7a9f4e2fa0ce467324db0512d8b33c4eb35100"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ termcolor = "^3.3.0"
 urllib3 = "^2.7.0"
 yara-python = "^4.5.4"
 nono-py = ">=0.10.1"
+packaging = ">=21.0"
 
 [tool.poetry.group.dev.dependencies]
 coverage = "^7.13.5"

--- a/uv.lock
+++ b/uv.lock
@@ -246,6 +246,7 @@ dependencies = [
     { name = "configparser" },
     { name = "disposable-email-domains" },
     { name = "nono-py" },
+    { name = "packaging" },
     { name = "prettytable" },
     { name = "pygit2" },
     { name = "python-dateutil" },
@@ -265,6 +266,7 @@ requires-dist = [
     { name = "configparser", specifier = ">=5.3,<8.0" },
     { name = "disposable-email-domains", specifier = ">=0.0.103,<0.0.170" },
     { name = "nono-py", specifier = ">=0.10.1" },
+    { name = "packaging", specifier = ">=21.0" },
     { name = "prettytable", specifier = ">=3.17.0,<4.0.0" },
     { name = "pygit2", specifier = ">=1.11,<1.19" },
     { name = "python-dateutil", specifier = ">=2.9.0,<3.0.0" },
@@ -313,6 +315,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ed/d9/2b4e26f650938e8081510681204c94cc1fcc97060ffdf4b71464007a1788/nono_py-0.10.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2a2f9d944b71b930aa7e7c4d156b363dfb63a85b3d07815f7d7cb6510fd531d2", size = 3294446, upload-time = "2026-05-23T12:59:18.872Z" },
     { url = "https://files.pythonhosted.org/packages/2a/d7/d87b4e934763379423a7545b901f27147beb3a571eb24eea1ea95f96b7ba/nono_py-0.10.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:04f1d46c3a85bdd0cc89d88e2771867941b6aff15b5dbd26104046297f86283e", size = 4736360, upload-time = "2026-05-23T12:59:20.636Z" },
     { url = "https://files.pythonhosted.org/packages/95/e2/61feb295647530e31bcf891ba16b0080ad65dbb2e7b7549fb8c8947830d0/nono_py-0.10.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:12db2cd45638e7576f8972090c0344d02a8b6d9c7ed6435fa2fbf1c8797742ae", size = 4938066, upload-time = "2026-05-23T12:59:22.64Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Two bugs caused all recall eval scans to fail with "Expected a directory but got a file":

- `setup_sandbox` called `caps.allow_path()` with `zip_path` and `output_path`, but nono_py's `allow_path()` only accepts directories. Files must be registered with `allow_file()` instead.
- `scan_package` called guarddog without `--no-sandbox`. The recall worker is already sandboxed by nono; guarddog trying to apply its own nono sandbox inside an already-sandboxed process fails with "Operation not permitted".

Also simplifies the dry-run validation loop since `query_path` only works for directories — only `tmp_dir` needs to be validated there.

## Test plan

- [ ] Delete stale cached results in `evals/workdir/recall_results/` and re-run `uv run evals/recall.py --phase scan`
- [ ] Verify scan errors drop to ~0 (or at least well below 100%)
- [ ] Run a single package manually: `uv run evals/recall_worker.py --zip-path <path> --ecosystem pypi --output-path /tmp/out.json --guarddog-bin .venv/bin/guarddog`