### PR TITLE
Fix sandbox crash in human-readable reporter when stripping path pref…

### DIFF
--- a/guarddog/reporters/human_readable.py
+++ b/guarddog/reporters/human_readable.py
@@ -125,12 +125,15 @@ class HumanReadableReporter(BaseReporter):
         if not prefix or not path:
             return path
         loc, _, line = path.partition(":")
-        try:
-            rel = os.path.relpath(loc, prefix)
-        except ValueError:
+        # Avoid os.path.relpath here: it calls os.getcwd() (via abspath), which
+        # raises OSError under the scan sandbox, whose allow-list excludes the
+        # invocation directory. prefix always comes from os.path.commonpath over
+        # the locations, so it is an ancestor of loc and a plain string strip is
+        # both correct and getcwd-free.
+        prefix = prefix.rstrip(os.sep)
+        if loc == prefix or not loc.startswith(prefix + os.sep):
             return path
-        if rel.startswith(".."):
-            return path
+        rel = loc[len(prefix) + 1 :]
         return f"{rel}:{line}" if line else rel
 
     @staticmethod

--- a/tests/reporters/test_human_readable.py
+++ b/tests/reporters/test_human_readable.py
@@ -1,4 +1,5 @@
 import re
+from unittest import mock
 
 from guarddog.reporters.human_readable import HumanReadableReporter, _sanitize
 
@@ -162,3 +163,21 @@ def test_print_scan_results_benign_input_is_preserved():
     assert "matched a benign-looking pattern" in plain
     assert "requests" in plain
     assert "rule-name" in plain
+
+
+def test_strip_prefix():
+    strip = HumanReadableReporter._strip_prefix
+    # Strips a common ancestor; leaves non-descendants and edge cases untouched.
+    assert strip("package/dist/node/axios.cjs:42", "package/dist") == "node/axios.cjs:42"
+    assert strip("package/dist/axios.js:7", "package/dist/") == "axios.js:7"
+    assert strip("other/file.js:1", "package/dist") == "other/file.js:1"
+    assert strip("package/dist", "package/dist") == "package/dist"
+    assert strip("axios.js:5", None) == "axios.js:5"
+
+    # Under the scan sandbox os.getcwd() raises OSError; stripping must still
+    # work via plain string ops rather than crashing through relpath/abspath.
+    def blocked():
+        raise PermissionError(1, "Operation not permitted")
+
+    with mock.patch("os.getcwd", blocked):
+        assert strip("package/dist/node/axios.cjs:42", "package/dist") == "node/axios.cjs:42"


### PR DESCRIPTION
Sandboxed scans (default) crashed in the human-readable reporter because _strip_prefix used os.path.relpath, which calls os.getcwd(), was blocked by the kernel sandbox since the invocation directory is outside its allow-list. The reporter now strips the common path prefix with plain string operations, which doesn't require calling getcwdand keeps prefix-stripping working under the sandbox


Before the fix:

```
$ alias guarddogv3='uvx --from git+https://github.com/DataDog/guarddog@v3 guarddog'
$ guarddogv3 npm scan axios
Traceback (most recent call last):
  File "/Users/christophe.tafanidereeper/.cache/uv/archive-v0/kk93AWVV8hyRfJcD/bin/guarddog", line 12, in <module>
    sys.exit(cli())
             ^^^^^
  File "/Users/christophe.tafanidereeper/.cache/uv/archive-v0/kk93AWVV8hyRfJcD/lib/python3.12/site-packages/click/core.py", line 1524, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/christophe.tafanidereeper/.cache/uv/archive-v0/kk93AWVV8hyRfJcD/lib/python3.12/site-packages/click/core.py", line 1445, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/christophe.tafanidereeper/.cache/uv/archive-v0/kk93AWVV8hyRfJcD/lib/python3.12/site-packages/click/core.py", line 1912, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/christophe.tafanidereeper/.cache/uv/archive-v0/kk93AWVV8hyRfJcD/lib/python3.12/site-packages/click/core.py", line 1912, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/christophe.tafanidereeper/.cache/uv/archive-v0/kk93AWVV8hyRfJcD/lib/python3.12/site-packages/click/core.py", line 1308, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/christophe.tafanidereeper/.cache/uv/archive-v0/kk93AWVV8hyRfJcD/lib/python3.12/site-packages/click/core.py", line 877, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/christophe.tafanidereeper/.cache/uv/archive-v0/kk93AWVV8hyRfJcD/lib/python3.12/site-packages/guarddog/cli.py", line 484, in scan_ecosystem
    return _scan(
           ^^^^^^
  File "/Users/christophe.tafanidereeper/.cache/uv/archive-v0/kk93AWVV8hyRfJcD/lib/python3.12/site-packages/guarddog/cli.py", line 334, in _scan
    stdout, stderr = reporter.render_scan(result)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/christophe.tafanidereeper/.cache/uv/archive-v0/kk93AWVV8hyRfJcD/lib/python3.12/site-packages/guarddog/reporters/human_readable.py", line 351, in render_scan
    HumanReadableReporter.print_scan_results(
  File "/Users/christophe.tafanidereeper/.cache/uv/archive-v0/kk93AWVV8hyRfJcD/lib/python3.12/site-packages/guarddog/reporters/human_readable.py", line 336, in print_scan_results
    lines += HumanReadableReporter._format_findings(risks, path_prefix, ceiling)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/christophe.tafanidereeper/.cache/uv/archive-v0/kk93AWVV8hyRfJcD/lib/python3.12/site-packages/guarddog/reporters/human_readable.py", line 277, in _format_findings
    lines += HumanReadableReporter._format_one_risk(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/christophe.tafanidereeper/.cache/uv/archive-v0/kk93AWVV8hyRfJcD/lib/python3.12/site-packages/guarddog/reporters/human_readable.py", line 216, in _format_one_risk
    HumanReadableReporter._strip_prefix(loc_raw, path_prefix)
  File "/Users/christophe.tafanidereeper/.cache/uv/archive-v0/kk93AWVV8hyRfJcD/lib/python3.12/site-packages/guarddog/reporters/human_readable.py", line 129, in _strip_prefix
    rel = os.path.relpath(loc, prefix)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen posixpath>", line 519, in relpath
  File "<frozen posixpath>", line 415, in abspath
PermissionError: [Errno 1] Operation not permitted
```


After the fix:

```
$ alias guarddogv3='uvx --from git+https://github.com/DataDog/guarddog@christophe.tafanidereeper/v3-sandbox-fix guarddog'
$ guarddogv3 npm scan axios
(...)
Assessment:  Low risk  (4.5/10)
```