### PR TITLE
Make lolbas-sysinfo detection language-agnostic

### DIFF
--- a/guarddog/analyzer/sourcecode/lolbas-sysinfo.meta
+++ b/guarddog/analyzer/sourcecode/lolbas-sysinfo.meta
@@ -1,14 +1,24 @@
 // Private rule for LOLBAS system information gathering tools detection
 // These patterns are reused across multiple threat and capability rules
+// Patterns require invocation context: flags, paths, or an exec wrapper
 
 rule lolbas_sysinfo
 {
     strings:
-        // Require the sysinfo command to appear as the argument of an exec call,
-        // so dict keys (result['hostname']), XML lookups (findall("hostname"))
-        // and API paths (/workers/whoami) no longer match.
-        $whoami = /\b(popen|system|getoutput|getstatusoutput|check_output|check_call|Popen|run|call|spawn\w*|execl?p?e?|exec_command)\s*\(\s*\[?\s*['"]whoami\b/ nocase
-        $hostname = /\b(popen|system|getoutput|getstatusoutput|check_output|check_call|Popen|run|call|spawn\w*|execl?p?e?|exec_command)\s*\(\s*\[?\s*['"]hostname\b/ nocase
+        // Invoked as an OS command with tool-specific flags (language-agnostic)
+        $whoami_flag = /\bwhoami\s+\/(all|user|groups|priv|fqdn|upn|logonid)\b/ nocase
+        $hostname_flag = /\bhostname\s+(--fqdn|-[AdfiIsy])\b/
+
+        // Invoked via an absolute binary path
+        $whoami_path = /\/(usr\/)?bin\/whoami\b/
+        $hostname_path = /\/(usr\/)?bin\/hostname\b/
+
+        // Passed as the argument of an exec call, which covers the bare
+        // no-argument invocation. The exec context excludes dict keys
+        // (result['hostname']), XML lookups (findall("hostname")) and API
+        // paths (/workers/whoami), which a bare keyword match would flag.
+        $whoami_exec = /\b(popen|system|getoutput|getstatusoutput|check_output|check_call|Popen|run|call|spawn\w*|execl?p?e?|exec_command)\s*\(\s*\[?\s*['"]whoami\b/ nocase
+        $hostname_exec = /\b(popen|system|getoutput|getstatusoutput|check_output|check_call|Popen|run|call|spawn\w*|execl?p?e?|exec_command)\s*\(\s*\[?\s*['"]hostname\b/ nocase
 
     condition:
         any of them

--- a/tests/analyzer/sourcecode/threat-process-sysinfo.py
+++ b/tests/analyzer/sourcecode/threat-process-sysinfo.py
@@ -8,3 +8,11 @@ def collect():
     host = os.popen("hostname").read()
     user = subprocess.run(["whoami"], capture_output=True)
     return host, user
+
+
+# Detected by command context (flags, absolute path) regardless of the host
+# language, not just by a Python-specific exec wrapper.
+def collect_via_command():
+    os.system("whoami /all")
+    subprocess.run("hostname -I", shell=True)
+    return "/usr/bin/whoami"


### PR DESCRIPTION
## What

Makes the `lolbas-sysinfo` detection (`whoami` / `hostname`) language-agnostic, addressing review feedback on PR #769 ([comment](https://github.com/DataDog/guarddog/pull/769#discussion_r3422100408)).

## Why

PR #769 narrowed the `whoami`/`hostname` patterns to require a Python exec wrapper (`popen`, `check_call`, `Popen`, ...) in order to kill false positives where these words appear as dict keys (`result['hostname']`), XML element lookups (`findall("hostname")`) or API path segments (`/workers/whoami`).

That fixed the FPs, but as @sobregosodd pointed out in review, it made the rule Python-dependent and drifted from the spirit of the `.meta` rule: in LOLBAS detection the OS command itself is the indicator, independent of the host language. The sibling helpers `lolbas-proc.meta` and `lolbas-net.meta` already follow that spirit by matching commands via intrinsic invocation context (flags, paths, pipes, URLs) rather than a language-specific wrapper.

## How

Adds language-agnostic invocation patterns alongside the existing exec wrapper:

- **tool-specific flags** — `whoami /all`, `hostname -I`, etc.
- **absolute binary paths** — `/usr/bin/whoami`, `/bin/hostname`

The exec-wrapper patterns are kept unchanged, so:
- the bare no-argument invocation (`subprocess.run(["whoami"])`) is still caught, and
- PR #769's false-positive fixes are fully preserved (the dict-key / XML / API-path benign cases still don't match).

The positive fixture is extended to cover the new flag/path detections, which would not have matched under #769's Python-exec-only regex.

## Testing

```
uv run pytest tests/analyzer/sourcecode/test_sourcecode_yara.py
```

All 132 cases pass, including the positive and benign regression fixtures for `threat-process-sysinfo`.
