### PR TITLE
Add S3 scanning mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ guarddog pypi scan /tmp/triage.tar.gz
 # Scan a local package directory
 guarddog pypi scan /tmp/triage/
 
+# Scan a package stored in S3 (a folder/prefix or a single archive object)
+guarddog pypi scan s3://my-bucket/path/to/package/
+guarddog pypi scan s3://my-bucket/path/to/package.tar.gz
+
 # Scan every package referenced in a requirements.txt file of a local folder
 guarddog pypi verify workspace/guarddog/requirements.txt
 
@@ -176,6 +180,17 @@ For remote packages, three phases run with different privilege levels:
 3. **Source code analysis** (YARA) runs in the main process after a sandbox is applied (network blocked, filesystem restricted to extracted files)
 
 The sandbox was introduced to mitigate path traversal and code execution vulnerabilities during archive extraction (CVE-2022-23530, CVE-2022-23531, CVE-2026-22870, CVE-2026-22871).
+
+## Scanning packages from S3
+
+GuardDog can scan a package stored in S3, either as a folder/prefix or a single archive object:
+
+```sh
+guarddog npm scan s3://my-bucket/path/to/package/
+guarddog npm scan s3://my-bucket/path/to/package.tar.gz
+```
+
+This uses your existing AWS credentials (environment variables, `~/.aws`, SSO, or an IAM role). GuardDog verifies authentication via STS before doing anything and exits with an error if no valid credentials are found. The objects are synced to a temporary directory, scanned under the sandbox like any other untrusted content, and removed from disk afterward.
 
 ## Rules
 

--- a/guarddog/cli.py
+++ b/guarddog/cli.py
@@ -314,6 +314,43 @@ def _scan(
                     extract_dir, rule_param, info=metadata_info
                 )
 
+        elif identifier.startswith("s3://"):
+            log.debug(f"Considering that '{identifier}' is an S3 path")
+            if version is not None:
+                log.error("--version is not supported for S3 scans")
+                sys.exit(1)
+            from guarddog.utils.s3 import (
+                verify_aws_authentication,
+                download_from_s3,
+            )
+
+            try:
+                verify_aws_authentication()
+            except Exception as e:
+                log.error(f"AWS authentication failed: {e}")
+                sys.exit(1)
+            tmp_root = os.path.realpath(tempfile.gettempdir())
+            with tempfile.TemporaryDirectory(dir=tmp_root) as tempdir:
+                download_root = os.path.join(tempdir, "_s3")
+                os.makedirs(download_root, exist_ok=True)
+                # Sync before sandbox: network access is needed here (mirrors the
+                # http/https branch).
+                kind, local_path = download_from_s3(identifier, download_root)
+                if sandbox:
+                    apply_sandbox(scan_paths=[], writable_paths=[tempdir])
+                if kind == "archive":
+                    extract_dir = os.path.join(tempdir, "_extracted")
+                    os.makedirs(extract_dir, exist_ok=True)
+                    safe_extract(
+                        local_path, extract_dir, zip_password=zip_password_bytes
+                    )
+                    scan_target = extract_dir
+                else:
+                    scan_target = local_path
+                result |= scanner.scan_local(
+                    scan_target, rule_param, info=metadata_info
+                )
+
         else:
             log.debug(f"Considering that '{identifier}' is a remote target")
             if zip_password_bytes is not None:

--- a/guarddog/utils/s3.py
+++ b/guarddog/utils/s3.py
@@ -96,6 +96,24 @@ def download_from_s3(s3_uri: str, dest_dir: str) -> Tuple[str, str]:
     if key and not key.endswith("/"):
         try:
             client.head_object(Bucket=bucket, Key=key)
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code")
+            # 404/NoSuchKey: no object at the bare key -> treat it as a prefix.
+            # 403/AccessDenied: the caller may lack HeadObject on the bare key while
+            # still being able to ListBucket + GetObject under <key>/ (a common IAM
+            # setup for folder scans), so fall back to a prefix sync rather than
+            # failing outright.
+            fall_through = (
+                "404",
+                "NoSuchKey",
+                "NotFound",
+                "403",
+                "AccessDenied",
+                "Forbidden",
+            )
+            if error_code not in fall_through:
+                raise
+        else:
             local_path = _safe_join(dest_dir, os.path.basename(key))
             os.makedirs(os.path.dirname(local_path), exist_ok=True)
             log.debug(f"Downloading s3://{bucket}/{key} -> {local_path}")
@@ -103,11 +121,6 @@ def download_from_s3(s3_uri: str, dest_dir: str) -> Tuple[str, str]:
             if is_supported_archive(local_path):
                 return "archive", local_path
             return "folder", dest_dir
-        except ClientError as e:
-            error_code = e.response.get("Error", {}).get("Code")
-            if error_code not in ("404", "NoSuchKey", "NotFound"):
-                raise
-            # Not a single object: fall through and treat the key as a prefix.
 
     _download_prefix(client, bucket, key, dest_dir)
     return "folder", dest_dir
@@ -119,20 +132,27 @@ def _download_prefix(client, bucket: str, prefix: str, dest_dir: str) -> None:
     Objects are downloaded concurrently via a thread pool; the boto3 low-level client
     is thread-safe and shared across workers.
     """
+    # Normalize to a folder boundary so a bare prefix like "path/pkg" doesn't also
+    # match sibling keys such as "path/pkg-other/..." (list_objects_v2 Prefix
+    # matching is purely lexical, not path-segment aware).
+    list_prefix = prefix.rstrip("/")
+    if list_prefix:
+        list_prefix += "/"
+
     paginator = client.get_paginator("list_objects_v2")
     jobs: List[Tuple[str, str]] = []  # (object_key, local_path)
-    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+    for page in paginator.paginate(Bucket=bucket, Prefix=list_prefix):
         for obj in page.get("Contents", []):
             object_key = obj["Key"]
             if object_key.endswith("/"):
                 continue
             relative_path = (
-                os.path.relpath(object_key, prefix) if prefix else object_key
+                os.path.relpath(object_key, list_prefix) if list_prefix else object_key
             )
             jobs.append((object_key, _safe_join(dest_dir, relative_path)))
 
     if not jobs:
-        raise RuntimeError(f"no objects found at s3://{bucket}/{prefix}")
+        raise RuntimeError(f"no objects found at s3://{bucket}/{list_prefix}")
 
     # Create parent directories up front so parallel downloads don't race on mkdir.
     for _, local_path in jobs:

--- a/guarddog/utils/s3.py
+++ b/guarddog/utils/s3.py
@@ -1,0 +1,150 @@
+"""Helpers for fetching packages from S3 so they can be scanned locally.
+
+boto3 is imported lazily inside each function so that a normal (non-S3) scan never
+pays the cost of importing it. boto3 has no built-in directory sync (`aws s3 sync`
+lives in awscli), so folder syncs iterate objects under the prefix and download each
+one; the per-object transfers still use boto3's managed multipart + retries.
+"""
+
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor
+from typing import List, Tuple
+from urllib.parse import urlparse
+
+from guarddog.utils.archives import is_supported_archive
+
+log = logging.getLogger("guarddog")
+
+# S3 syncs of real packages are dominated by per-object request latency, so objects
+# are downloaded concurrently. This work is I/O-bound, not CPU-bound, so the worker
+# count is a fixed fan-out rather than a function of core count. The botocore HTTP
+# connection pool must be sized to match, otherwise excess workers stall waiting for
+# a free connection (botocore defaults the pool to 10).
+MAX_DOWNLOAD_WORKERS = 16
+
+
+def is_s3_url(identifier: str) -> bool:
+    """Return True when the scan target is an S3 URL (s3://bucket/key)."""
+    return identifier.startswith("s3://")
+
+
+def parse_s3_uri(uri: str) -> Tuple[str, str]:
+    """Split an s3://bucket/key URI into (bucket, key)."""
+    parsed = urlparse(uri)
+    bucket = parsed.netloc
+    key = parsed.path.lstrip("/")
+    if not bucket:
+        raise ValueError(f"Invalid S3 URI (missing bucket): {uri}")
+    return bucket, key
+
+
+def verify_aws_authentication() -> None:
+    """Confirm the caller is authenticated to AWS, raising RuntimeError otherwise.
+
+    Uses STS GetCallerIdentity, which requires no specific permissions beyond a valid
+    set of credentials. The CLI turns the RuntimeError into a clean error + exit.
+    """
+    import boto3  # type: ignore
+    from botocore.exceptions import (  # type: ignore
+        BotoCoreError,
+        ClientError,
+        NoCredentialsError,
+    )
+
+    try:
+        boto3.client("sts").get_caller_identity()
+    except NoCredentialsError as e:
+        raise RuntimeError(
+            "no AWS credentials found. Configure credentials (env vars, ~/.aws, "
+            f"SSO, or an IAM role) before scanning an S3 path. ({e})"
+        )
+    except (ClientError, BotoCoreError) as e:
+        raise RuntimeError(f"could not verify AWS identity via STS: {e}")
+
+
+def _safe_join(dest_dir: str, relative_path: str) -> str:
+    """Join dest_dir and an S3-derived relative path, refusing to escape dest_dir.
+
+    S3 keys can contain '..' segments; without this guard a crafted key could write
+    outside the temp directory.
+    """
+    dest_dir = os.path.realpath(dest_dir)
+    target = os.path.realpath(os.path.join(dest_dir, relative_path))
+    if target != dest_dir and not target.startswith(dest_dir + os.sep):
+        raise ValueError(f"S3 key escapes destination directory: {relative_path}")
+    return target
+
+
+def download_from_s3(s3_uri: str, dest_dir: str) -> Tuple[str, str]:
+    """Download an S3 object or prefix into dest_dir.
+
+    Returns (kind, local_path):
+      - ("archive", <file path>) when the URI points at a single supported archive
+      - ("folder", dest_dir) when the URI is a prefix (or a single non-archive object)
+    """
+    import boto3  # type: ignore
+    from botocore.config import Config  # type: ignore
+    from botocore.exceptions import ClientError  # type: ignore
+
+    bucket, key = parse_s3_uri(s3_uri)
+    # Size the connection pool to the download fan-out so workers don't stall on it.
+    client = boto3.client(
+        "s3", config=Config(max_pool_connections=MAX_DOWNLOAD_WORKERS)
+    )
+
+    if key and not key.endswith("/"):
+        try:
+            client.head_object(Bucket=bucket, Key=key)
+            local_path = _safe_join(dest_dir, os.path.basename(key))
+            os.makedirs(os.path.dirname(local_path), exist_ok=True)
+            log.debug(f"Downloading s3://{bucket}/{key} -> {local_path}")
+            client.download_file(bucket, key, local_path)
+            if is_supported_archive(local_path):
+                return "archive", local_path
+            return "folder", dest_dir
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code")
+            if error_code not in ("404", "NoSuchKey", "NotFound"):
+                raise
+            # Not a single object: fall through and treat the key as a prefix.
+
+    _download_prefix(client, bucket, key, dest_dir)
+    return "folder", dest_dir
+
+
+def _download_prefix(client, bucket: str, prefix: str, dest_dir: str) -> None:
+    """Download every object under prefix into dest_dir, preserving relative paths.
+
+    Objects are downloaded concurrently via a thread pool; the boto3 low-level client
+    is thread-safe and shared across workers.
+    """
+    paginator = client.get_paginator("list_objects_v2")
+    jobs: List[Tuple[str, str]] = []  # (object_key, local_path)
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            object_key = obj["Key"]
+            if object_key.endswith("/"):
+                continue
+            relative_path = (
+                os.path.relpath(object_key, prefix) if prefix else object_key
+            )
+            jobs.append((object_key, _safe_join(dest_dir, relative_path)))
+
+    if not jobs:
+        raise RuntimeError(f"no objects found at s3://{bucket}/{prefix}")
+
+    # Create parent directories up front so parallel downloads don't race on mkdir.
+    for _, local_path in jobs:
+        os.makedirs(os.path.dirname(local_path), exist_ok=True)
+
+    def _download(job: Tuple[str, str]) -> None:
+        object_key, local_path = job
+        log.debug(f"Downloading s3://{bucket}/{object_key} -> {local_path}")
+        client.download_file(bucket, object_key, local_path)
+
+    worker_count = min(MAX_DOWNLOAD_WORKERS, len(jobs))
+    with ThreadPoolExecutor(max_workers=worker_count) as executor:
+        # Consume the iterator so the first download error propagates.
+        for _ in executor.map(_download, jobs):
+            pass

--- a/poetry.lock
+++ b/poetry.lock
@@ -54,6 +54,46 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2) ; sys_platform != \"win32\"", "winloop (>=0.5.0) ; sys_platform == \"win32\""]
 
 [[package]]
+name = "boto3"
+version = "1.43.31"
+description = "The AWS SDK for Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "boto3-1.43.31-py3-none-any.whl", hash = "sha256:69c5521ad864f33d4d53b0e18a3927697f4558210693b1cb4dd97da959d1f7b9"},
+    {file = "boto3-1.43.31.tar.gz", hash = "sha256:8165b79c02955affbe4b4e9aa7c560684d0d4d86b4b9de66a37b45eb79fc4b69"},
+]
+
+[package.dependencies]
+botocore = ">=1.43.31,<1.44.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.19.0,<0.20.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
+name = "botocore"
+version = "1.43.31"
+description = "Low-level, data-driven core of boto 3."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "botocore-1.43.31-py3-none-any.whl", hash = "sha256:4c51c63f39515fc1a2b8e3e2c29e452009c988ba55ad489251658fdd3aedad6e"},
+    {file = "botocore-1.43.31.tar.gz", hash = "sha256:c249625faaa353c5b4004043706a394a4f3bcd3643e242f6b01fff6dc70e988b"},
+]
+
+[package.dependencies]
+jmespath = ">=0.7.1,<2.0.0"
+python-dateutil = ">=2.1,<3.0.0"
+urllib3 = ">=1.25.4,<2.2.0 || >2.2.0,<3"
+
+[package.extras]
+crt = ["awscrt (==0.32.2)"]
+
+[[package]]
 name = "certifi"
 version = "2026.5.20"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -823,6 +863,18 @@ MarkupSafe = ">=2.0"
 
 [package.extras]
 i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+description = "JSON Matching Expressions"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64"},
+    {file = "jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d"},
+]
 
 [[package]]
 name = "jsonpath-ng"
@@ -2232,6 +2284,24 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<8)"]
 
 [[package]]
+name = "s3transfer"
+version = "0.19.0"
+description = "An Amazon S3 Transfer Manager"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "s3transfer-0.19.0-py3-none-any.whl", hash = "sha256:777cc2415536f1debadb5c2ef7779275d0fc0fe0e042411cdd6caebeb2685262"},
+    {file = "s3transfer-0.19.0.tar.gz", hash = "sha256:ce436931687addc4c1712d52d40b32f53e88315723f107ffa20ba82b05a0f685"},
+]
+
+[package.dependencies]
+botocore = ">=1.37.4,<2.0a0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.37.4,<2.0a0)"]
+
+[[package]]
 name = "sarif-tools"
 version = "3.0.5"
 description = "SARIF tools"
@@ -2479,4 +2549,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4"
-content-hash = "92749085fc08755b4679625701139170207f6b137e8c4be99a61fb8a8c0e0de8"
+content-hash = "53c957abe38508376210eef9a0b0fde6d5940dcecbc5a153770e9d47d7c84409"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ urllib3 = "^2.7.0"
 yara-python = "^4.5.4"
 nono-py = ">=0.10.1"
 packaging = ">=21.0"
+boto3 = "^1.34"
 
 [tool.poetry.group.dev.dependencies]
 coverage = "^7.13.5"

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -60,7 +60,13 @@ class TestCli(unittest.TestCase):
                 listdir.return_value = []
                 with self.assertLogs("guarddog", level="DEBUG") as cm:
                     guarddog.cli._scan(
-                        directory, "0.1.0", (), (), None, False, ECOSYSTEM.PYPI,
+                        directory,
+                        "0.1.0",
+                        (),
+                        (),
+                        None,
+                        False,
+                        ECOSYSTEM.PYPI,
                         sandbox=False,
                     )
                 self.assertIn(
@@ -86,7 +92,13 @@ class TestCli(unittest.TestCase):
                 ) as _:
                     with self.assertLogs("guarddog", level="DEBUG") as cm:
                         guarddog.cli._scan(
-                            directory, "0.1.0", (), (), None, False, ECOSYSTEM.PYPI,
+                            directory,
+                            "0.1.0",
+                            (),
+                            (),
+                            None,
+                            False,
+                            ECOSYSTEM.PYPI,
                             sandbox=False,
                         )
                     self.assertNotIn(
@@ -115,7 +127,11 @@ class TestCli(unittest.TestCase):
                     guarddog.cli._scan(
                         "https://example.com/package.whl",
                         "1.0.0",
-                        (), (), None, False, ECOSYSTEM.PYPI,
+                        (),
+                        (),
+                        None,
+                        False,
+                        ECOSYSTEM.PYPI,
                         sandbox=False,
                     )
 
@@ -125,14 +141,22 @@ class TestCli(unittest.TestCase):
 
         with mock.patch("os.path.isdir", return_value=False):
             with mock.patch("os.path.isfile", return_value=False):
-                with mock.patch("guarddog.cli.requests.get", return_value=mock_response):
+                with mock.patch(
+                    "guarddog.cli.requests.get", return_value=mock_response
+                ):
                     with mock.patch("guarddog.cli.safe_extract"):
                         with mock.patch.object(
                             scanner.PackageScanner, "scan_local", return_value={}
                         ):
                             with self.assertLogs("guarddog", level="DEBUG") as cm:
                                 guarddog.cli._scan(
-                                    url, None, (), (), None, False, ECOSYSTEM.PYPI,
+                                    url,
+                                    None,
+                                    (),
+                                    (),
+                                    None,
+                                    False,
+                                    ECOSYSTEM.PYPI,
                                     sandbox=False,
                                 )
                             self.assertIn(
@@ -161,7 +185,12 @@ class TestCli(unittest.TestCase):
                             with self.assertLogs("guarddog", level="DEBUG") as cm:
                                 guarddog.cli._scan(
                                     "s3://bucket/path/to/pkg",
-                                    None, (), (), None, False, ECOSYSTEM.NPM,
+                                    None,
+                                    (),
+                                    (),
+                                    None,
+                                    False,
+                                    ECOSYSTEM.NPM,
                                     sandbox=False,
                                 )
                             self.assertIn(
@@ -187,7 +216,12 @@ class TestCli(unittest.TestCase):
                     with self.assertRaises(SystemExit):
                         guarddog.cli._scan(
                             "s3://bucket/path/to/pkg",
-                            None, (), (), None, False, ECOSYSTEM.NPM,
+                            None,
+                            (),
+                            (),
+                            None,
+                            False,
+                            ECOSYSTEM.NPM,
                             sandbox=False,
                         )
 
@@ -198,9 +232,78 @@ class TestCli(unittest.TestCase):
                 with self.assertRaises(SystemExit):
                     guarddog.cli._scan(
                         "s3://bucket/path/to/pkg",
-                        "1.0.0", (), (), None, False, ECOSYSTEM.NPM,
+                        "1.0.0",
+                        (),
+                        (),
+                        None,
+                        False,
+                        ECOSYSTEM.NPM,
                         sandbox=False,
                     )
+
+    def test_s3_archive_object_is_extracted(self):
+        """A single archive object from S3 is extracted before scanning"""
+        with mock.patch("os.path.isdir", return_value=False):
+            with mock.patch("os.path.isfile", return_value=False):
+                with mock.patch("guarddog.utils.s3.verify_aws_authentication"):
+                    with mock.patch(
+                        "guarddog.utils.s3.download_from_s3",
+                        return_value=("archive", "/tmp/dl/pkg.tgz"),
+                    ):
+                        with mock.patch("guarddog.cli.safe_extract") as safe_extract:
+                            with mock.patch.object(
+                                scanner.PackageScanner, "scan_local", return_value={}
+                            ) as scan_local:
+                                guarddog.cli._scan(
+                                    "s3://bucket/path/pkg.tgz",
+                                    None,
+                                    (),
+                                    (),
+                                    None,
+                                    False,
+                                    ECOSYSTEM.NPM,
+                                    sandbox=False,
+                                )
+                            safe_extract.assert_called_once()
+                            scan_local.assert_called_once()
+                            # Scans the extracted dir, not the raw archive.
+                            self.assertTrue(
+                                scan_local.call_args.args[0].endswith("_extracted")
+                            )
+
+    def test_s3_sync_runs_before_sandbox(self):
+        """The S3 sync (needs network) must run before the sandbox is applied"""
+        order = []
+        with mock.patch("os.path.isdir", return_value=False):
+            with mock.patch("os.path.isfile", return_value=False):
+                with mock.patch("guarddog.cli.sandbox_available", return_value=True):
+                    with mock.patch("guarddog.utils.s3.verify_aws_authentication"):
+                        with mock.patch(
+                            "guarddog.utils.s3.download_from_s3",
+                            side_effect=lambda *a, **k: (
+                                order.append("download") or ("folder", "/tmp/synced")
+                            ),
+                        ):
+                            with mock.patch(
+                                "guarddog.cli.apply_sandbox",
+                                side_effect=lambda *a, **k: order.append("sandbox"),
+                            ):
+                                with mock.patch.object(
+                                    scanner.PackageScanner,
+                                    "scan_local",
+                                    return_value={},
+                                ):
+                                    guarddog.cli._scan(
+                                        "s3://bucket/path/pkg",
+                                        None,
+                                        (),
+                                        (),
+                                        None,
+                                        False,
+                                        ECOSYSTEM.NPM,
+                                        sandbox=True,
+                                    )
+        self.assertEqual(order, ["download", "sandbox"])
 
     def _test_local_file_template(self, filename: str):
         # `filename` is a file
@@ -255,7 +358,13 @@ class TestCli(unittest.TestCase):
                 ) as _:
                     with self.assertLogs("guarddog", level="DEBUG") as cm:
                         guarddog.cli._scan(
-                            filename, "0.1.0", (), (), None, False, ECOSYSTEM.PYPI,
+                            filename,
+                            "0.1.0",
+                            (),
+                            (),
+                            None,
+                            False,
+                            ECOSYSTEM.PYPI,
                             sandbox=False,
                         )
                     self.assertNotIn(

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -144,6 +144,64 @@ class TestCli(unittest.TestCase):
                                 cm.output,
                             )
 
+    def test_s3_url(self):
+        """Test that the CLI routes s3:// targets through the S3 branch"""
+        with mock.patch("os.path.isdir", return_value=False):
+            with mock.patch("os.path.isfile", return_value=False):
+                with mock.patch(
+                    "guarddog.utils.s3.verify_aws_authentication"
+                ) as verify:
+                    with mock.patch(
+                        "guarddog.utils.s3.download_from_s3",
+                        return_value=("folder", "/tmp/synced"),
+                    ) as download:
+                        with mock.patch.object(
+                            scanner.PackageScanner, "scan_local", return_value={}
+                        ) as scan_local:
+                            with self.assertLogs("guarddog", level="DEBUG") as cm:
+                                guarddog.cli._scan(
+                                    "s3://bucket/path/to/pkg",
+                                    None, (), (), None, False, ECOSYSTEM.NPM,
+                                    sandbox=False,
+                                )
+                            self.assertIn(
+                                "DEBUG:guarddog:Considering that "
+                                "'s3://bucket/path/to/pkg' is an S3 path",
+                                cm.output,
+                            )
+                            verify.assert_called_once()
+                            download.assert_called_once()
+                            scan_local.assert_called_once()
+                            self.assertEqual(
+                                scan_local.call_args.args[0], "/tmp/synced"
+                            )
+
+    def test_s3_url_auth_failure_exits(self):
+        """Test that a failed AWS auth check exits non-zero for S3 scans"""
+        with mock.patch("os.path.isdir", return_value=False):
+            with mock.patch("os.path.isfile", return_value=False):
+                with mock.patch(
+                    "guarddog.utils.s3.verify_aws_authentication",
+                    side_effect=RuntimeError("no AWS credentials found"),
+                ):
+                    with self.assertRaises(SystemExit):
+                        guarddog.cli._scan(
+                            "s3://bucket/path/to/pkg",
+                            None, (), (), None, False, ECOSYSTEM.NPM,
+                            sandbox=False,
+                        )
+
+    def test_s3_url_rejects_version(self):
+        """Test that --version is rejected for S3 scans"""
+        with mock.patch("os.path.isdir", return_value=False):
+            with mock.patch("os.path.isfile", return_value=False):
+                with self.assertRaises(SystemExit):
+                    guarddog.cli._scan(
+                        "s3://bucket/path/to/pkg",
+                        "1.0.0", (), (), None, False, ECOSYSTEM.NPM,
+                        sandbox=False,
+                    )
+
     def _test_local_file_template(self, filename: str):
         # `filename` is a file
         with mock.patch("os.path.isdir") as isdir:

--- a/tests/core/test_s3.py
+++ b/tests/core/test_s3.py
@@ -1,0 +1,118 @@
+import os
+import unittest
+import unittest.mock as mock
+
+import pytest
+from botocore.exceptions import ClientError, NoCredentialsError
+
+from guarddog.utils import s3
+
+
+class TestS3Helpers(unittest.TestCase):
+    def test_is_s3_url(self):
+        assert s3.is_s3_url("s3://bucket/key")
+        assert not s3.is_s3_url("https://example.com/x")
+        assert not s3.is_s3_url("/local/path")
+
+    def test_parse_s3_uri(self):
+        assert s3.parse_s3_uri("s3://bucket/path/to/pkg") == (
+            "bucket",
+            "path/to/pkg",
+        )
+        assert s3.parse_s3_uri("s3://bucket/prefix/") == ("bucket", "prefix/")
+
+    def test_parse_s3_uri_missing_bucket(self):
+        with pytest.raises(ValueError):
+            s3.parse_s3_uri("s3:///key-without-bucket")
+
+    def test_safe_join_rejects_traversal(self):
+        with pytest.raises(ValueError):
+            s3._safe_join("/tmp/dest", "../../etc/passwd")
+
+    def test_safe_join_allows_nested(self):
+        result = s3._safe_join("/tmp/dest", "a/b/c.js")
+        assert result == os.path.realpath("/tmp/dest/a/b/c.js")
+
+
+class TestVerifyAuth(unittest.TestCase):
+    def test_missing_credentials_raises(self):
+        client = mock.MagicMock()
+        client.get_caller_identity.side_effect = NoCredentialsError()
+        with mock.patch("boto3.client", return_value=client):
+            with pytest.raises(RuntimeError):
+                s3.verify_aws_authentication()
+
+    def test_success(self):
+        client = mock.MagicMock()
+        with mock.patch("boto3.client", return_value=client):
+            s3.verify_aws_authentication()
+        client.get_caller_identity.assert_called_once()
+
+
+def _not_found_error():
+    return ClientError(
+        {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject"
+    )
+
+
+class TestDownloadFromS3(unittest.TestCase):
+    def test_single_archive_object(self):
+        client = mock.MagicMock()
+        client.head_object.return_value = {}
+        with mock.patch("boto3.client", return_value=client):
+            with mock.patch("os.makedirs"):
+                kind, path = s3.download_from_s3(
+                    "s3://bucket/path/pkg.tgz", "/tmp/dest"
+                )
+        assert kind == "archive"
+        assert path.endswith("pkg.tgz")
+        client.download_file.assert_called_once()
+
+    def test_single_non_archive_object_is_folder(self):
+        client = mock.MagicMock()
+        client.head_object.return_value = {}
+        with mock.patch("boto3.client", return_value=client):
+            with mock.patch("os.makedirs"):
+                kind, path = s3.download_from_s3(
+                    "s3://bucket/path/index.js", "/tmp/dest"
+                )
+        assert kind == "folder"
+        assert path == "/tmp/dest"
+
+    def test_prefix_downloads_each_object(self):
+        client = mock.MagicMock()
+        client.head_object.side_effect = _not_found_error()
+        paginator = mock.MagicMock()
+        paginator.paginate.return_value = [
+            {
+                "Contents": [
+                    {"Key": "path/pkg/"},  # directory marker, skipped
+                    {"Key": "path/pkg/package.json"},
+                    {"Key": "path/pkg/lib/index.js"},
+                ]
+            }
+        ]
+        client.get_paginator.return_value = paginator
+        with mock.patch("boto3.client", return_value=client):
+            with mock.patch("os.makedirs"):
+                kind, path = s3.download_from_s3(
+                    "s3://bucket/path/pkg", "/tmp/dest"
+                )
+        assert kind == "folder"
+        assert path == "/tmp/dest"
+        assert client.download_file.call_count == 2
+        downloaded_keys = {c.args[1] for c in client.download_file.call_args_list}
+        assert downloaded_keys == {
+            "path/pkg/package.json",
+            "path/pkg/lib/index.js",
+        }
+
+    def test_empty_prefix_raises(self):
+        client = mock.MagicMock()
+        client.head_object.side_effect = _not_found_error()
+        paginator = mock.MagicMock()
+        paginator.paginate.return_value = [{}]
+        client.get_paginator.return_value = paginator
+        with mock.patch("boto3.client", return_value=client):
+            with pytest.raises(RuntimeError):
+                s3.download_from_s3("s3://bucket/missing", "/tmp/dest")

--- a/tests/core/test_s3.py
+++ b/tests/core/test_s3.py
@@ -50,9 +50,19 @@ class TestVerifyAuth(unittest.TestCase):
 
 
 def _not_found_error():
+    return ClientError({"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject")
+
+
+def _access_denied_error():
     return ClientError(
-        {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject"
+        {"Error": {"Code": "AccessDenied", "Message": "Forbidden"}}, "HeadObject"
     )
+
+
+def _prefix_paginator(keys):
+    paginator = mock.MagicMock()
+    paginator.paginate.return_value = [{"Contents": [{"Key": k} for k in keys]}]
+    return paginator
 
 
 class TestDownloadFromS3(unittest.TestCase):
@@ -95,9 +105,7 @@ class TestDownloadFromS3(unittest.TestCase):
         client.get_paginator.return_value = paginator
         with mock.patch("boto3.client", return_value=client):
             with mock.patch("os.makedirs"):
-                kind, path = s3.download_from_s3(
-                    "s3://bucket/path/pkg", "/tmp/dest"
-                )
+                kind, path = s3.download_from_s3("s3://bucket/path/pkg", "/tmp/dest")
         assert kind == "folder"
         assert path == "/tmp/dest"
         assert client.download_file.call_count == 2
@@ -106,6 +114,28 @@ class TestDownloadFromS3(unittest.TestCase):
             "path/pkg/package.json",
             "path/pkg/lib/index.js",
         }
+        # The bare key must be normalized to a folder boundary so sibling prefixes
+        # (e.g. path/pkg-other/) are not pulled in by lexical Prefix matching.
+        paginator.paginate.assert_called_once_with(Bucket="bucket", Prefix="path/pkg/")
+
+    def test_head_object_forbidden_falls_back_to_prefix(self):
+        client = mock.MagicMock()
+        client.head_object.side_effect = _access_denied_error()
+        client.get_paginator.return_value = _prefix_paginator(["path/pkg/package.json"])
+        with mock.patch("boto3.client", return_value=client):
+            with mock.patch("os.makedirs"):
+                kind, _ = s3.download_from_s3("s3://bucket/path/pkg", "/tmp/dest")
+        assert kind == "folder"
+        assert client.download_file.call_count == 1
+
+    def test_unexpected_client_error_propagates(self):
+        client = mock.MagicMock()
+        client.head_object.side_effect = ClientError(
+            {"Error": {"Code": "500", "Message": "boom"}}, "HeadObject"
+        )
+        with mock.patch("boto3.client", return_value=client):
+            with pytest.raises(ClientError):
+                s3.download_from_s3("s3://bucket/path/pkg", "/tmp/dest")
 
     def test_empty_prefix_raises(self):
         client = mock.MagicMock()

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,34 @@ revision = 3
 requires-python = ">=3.10"
 
 [[package]]
+name = "boto3"
+version = "1.43.31"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a5/8a/1d33e395da9319b162046ff7d7e75550756425c2a236d8682b4a1bbdec1c/boto3-1.43.31.tar.gz", hash = "sha256:8165b79c02955affbe4b4e9aa7c560684d0d4d86b4b9de66a37b45eb79fc4b69", size = 113122, upload-time = "2026-06-16T19:45:02.677Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/66/67b54f12fc0c5b2dc6fd0c04ea4cf1e7fc4a9843de680a22070d1fd77901/boto3-1.43.31-py3-none-any.whl", hash = "sha256:69c5521ad864f33d4d53b0e18a3927697f4558210693b1cb4dd97da959d1f7b9", size = 140533, upload-time = "2026-06-16T19:44:59.93Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.31"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/17/225ae5e7253441ae3beadf26aa12c2f9ce292f386a4877a2ed0bb17d6014/botocore-1.43.31.tar.gz", hash = "sha256:c249625faaa353c5b4004043706a394a4f3bcd3643e242f6b01fff6dc70e988b", size = 15540929, upload-time = "2026-06-16T19:44:47.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1e/da5fdcb8438008d3c53a0c6de6a40cb10bdb7e02a6e034aef79bc2b66800/botocore-1.43.31-py3-none-any.whl", hash = "sha256:4c51c63f39515fc1a2b8e3e2c29e452009c988ba55ad489251658fdd3aedad6e", size = 15223619, upload-time = "2026-06-16T19:44:43.116Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -242,6 +270,7 @@ wheels = [
 name = "guarddog"
 source = { editable = "." }
 dependencies = [
+    { name = "boto3" },
     { name = "click" },
     { name = "configparser" },
     { name = "disposable-email-domains" },
@@ -262,6 +291,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "boto3", specifier = ">=1.34,<2.0" },
     { name = "click", specifier = ">=8.4.1,<9.0.0" },
     { name = "configparser", specifier = ">=5.3,<8.0" },
     { name = "disposable-email-domains", specifier = ">=0.0.103,<0.0.170" },
@@ -287,6 +317,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -495,6 +534,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/94/dcdaeb1713cab9c84def276cfac7388b17c7d9855bbcfe88d77e4dbafd44/s3transfer-0.19.0.tar.gz", hash = "sha256:ce436931687addc4c1712d52d40b32f53e88315723f107ffa20ba82b05a0f685", size = 165171, upload-time = "2026-06-16T19:44:51.599Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/5f/4c174edad94f82de888ac00a5ddd8d07b35609b6c94f0bdf4d74af57703e/s3transfer-0.19.0-py3-none-any.whl", hash = "sha256:777cc2415536f1debadb5c2ef7779275d0fc0fe0e042411cdd6caebeb2685262", size = 90101, upload-time = "2026-06-16T19:44:50.439Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Adds support for scanning a package stored in S3, alongside the existing local-directory, local-archive, and remote-URL modes. GuardDog detects the `s3://` scheme, verifies AWS authentication, syncs the contents to a temporary directory, scans them under the sandbox like any other untrusted content, and removes them from disk afterward.

Both layouts are supported: an S3 folder/prefix (synced object-by-object, preserving relative paths) and a single archive object (downloaded and run through `safe_extract` before scanning).

## Usage

```sh
# Scan a package stored as a folder/prefix in S3
guarddog npm scan s3://my-bucket/path/to/package/

# Scan a single archive object in S3
guarddog pypi scan s3://my-bucket/path/to/package.tar.gz
```

Authentication uses the standard AWS credential chain (environment variables, `~/.aws`, SSO, or an IAM role). GuardDog runs an STS `GetCallerIdentity` check up front and exits with a clear error if no valid credentials are found.

## Details

- New `guarddog/utils/s3.py` holds all boto3 logic (auth check, URI parsing, download), with a path-traversal guard so a crafted S3 key cannot escape the temp dir.
- The sync happens before the sandbox is applied (network is needed there), then the sandbox is applied and `scan_local` runs against the synced files. This mirrors the existing `http(s)` archive flow.
- Folder prefixes are downloaded concurrently with a thread pool; the botocore connection pool is sized to match the worker count so workers don't stall on connections.
- `boto3` added as a dependency.

## Tests

- `tests/core/test_s3.py`: URI parsing, auth-failure handling, single-archive vs prefix download, path-traversal rejection, empty-prefix handling.
- `tests/core/test_cli.py`: routing of `s3://` targets, auth-failure exit, and `--version` rejection.