### PR TITLE
Fix npm-http-dependency false positive on metadata URL fields

### DIFF
--- a/guarddog/analyzer/sourcecode/threat-npm-http-dependency.yar
+++ b/guarddog/analyzer/sourcecode/threat-npm-http-dependency.yar
@@ -17,14 +17,16 @@ rule threat_npm_http_dependency
         $http_url = /:\s*"https?:\/\/[^"]+\.(tar\.gz|tgz|zip)"/ nocase
         // Generic HTTP dependency pointing to non-standard hosts
         $http_plain = /:\s*"http:\/\/[^"]+"/
-        // Plain-http URLs in package metadata fields (author/repo/homepage).
-        // `url` covers the nested URL key used by author/repository/bugs/funding
-        // objects (e.g. "author": { "url": "http://..." }), a common false positive.
-        $http_meta = /"(url|web|website|homepage|funding|bugs|email|wiki|blog|docs|documentation|repository|author|maintainers|contributors|logo|image)"\s*:\s*"http:\/\//  nocase
+        // Plain-http URLs in flat package metadata fields (homepage, author-as-string, ...)
+        $http_meta = /"(web|website|homepage|funding|bugs|email|wiki|blog|docs|documentation|repository|author|maintainers|contributors|logo|image)"\s*:\s*"http:\/\//  nocase
+        // Plain-http URL under the nested `url` key of a metadata object, e.g.
+        // "author": { "url": "http://..." }. Scoped to metadata objects so a
+        // dependency literally named `url` with an http specifier is still reported.
+        $http_meta_url = /"(author|repository|bugs|funding|contributors|maintainers)"\s*:\s*[\[{][^}]*"url"\s*:\s*"http:\/\//  nocase
 
     condition:
         $http_ip or
         $http_url or
-        // a plain-http value that is not a metadata field = a dependency URL
-        (#http_plain > #http_meta)
+        // plain-http values beyond those explained by metadata = dependency URLs
+        (#http_plain > #http_meta + #http_meta_url)
 }

--- a/guarddog/analyzer/sourcecode/threat-npm-http-dependency.yar
+++ b/guarddog/analyzer/sourcecode/threat-npm-http-dependency.yar
@@ -17,8 +17,10 @@ rule threat_npm_http_dependency
         $http_url = /:\s*"https?:\/\/[^"]+\.(tar\.gz|tgz|zip)"/ nocase
         // Generic HTTP dependency pointing to non-standard hosts
         $http_plain = /:\s*"http:\/\/[^"]+"/
-        // Plain-http URLs in package metadata fields (author/repo/homepage)
-        $http_meta = /"(web|website|homepage|funding|bugs|email|wiki|blog|docs|documentation|repository|author|maintainers|contributors|logo|image)"\s*:\s*"http:\/\//  nocase
+        // Plain-http URLs in package metadata fields (author/repo/homepage).
+        // `url` covers the nested URL key used by author/repository/bugs/funding
+        // objects (e.g. "author": { "url": "http://..." }), a common false positive.
+        $http_meta = /"(url|web|website|homepage|funding|bugs|email|wiki|blog|docs|documentation|repository|author|maintainers|contributors|logo|image)"\s*:\s*"http:\/\//  nocase
 
     condition:
         $http_ip or

--- a/tests/analyzer/sourcecode/benign/threat-npm-http-dependency.json
+++ b/tests/analyzer/sourcecode/benign/threat-npm-http-dependency.json
@@ -1,6 +1,19 @@
 {
   "name": "legit-package",
   "version": "2.0.0",
+  "author": {
+    "name": "Jane Developer",
+    "email": "jane@example.test",
+    "url": "http://jane.example.test"
+  },
+  "homepage": "http://example.test",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/example-org/example-pkg.git"
+  },
+  "bugs": {
+    "url": "http://github.com/example-org/example-pkg/issues"
+  },
   "dependencies": {
     "express": "^4.18.0",
     "lodash": "^4.17.21"

--- a/tests/analyzer/sourcecode/threat-npm-http-dependency.url-dep.json
+++ b/tests/analyzer/sourcecode/threat-npm-http-dependency.url-dep.json
@@ -1,0 +1,11 @@
+{
+  "name": "evil-url-dependency",
+  "version": "1.0.0",
+  "author": {
+    "name": "Jane Developer",
+    "url": "http://jane.example.test"
+  },
+  "dependencies": {
+    "url": "http://evil.example.test/payload"
+  }
+}


### PR DESCRIPTION
## Problem

The `npm-http-dependency` rule flags packages whose `package.json` contains a plain `http://` URL that isn't a recognized metadata field, on the assumption it's a dependency specifier (`#http_plain > #http_meta`), but some legitimate package.json files matched, especially some with nested `author.url` keys (see regression test)