### PR TITLE
Rename main branch to v2 in CI workflows and docs

### DIFF
--- a/.github/chainguard/self.github.tag-release.v2.sts.yaml
+++ b/.github/chainguard/self.github.tag-release.v2.sts.yaml
@@ -1,11 +1,11 @@
 # Policy for: .github/workflows/tag-release.yml (job: package-validation) in DataDog/guarddog
 issuer: https://token.actions.githubusercontent.com
-subject: repo:DataDog/guarddog:ref:refs/heads/main
+subject: repo:DataDog/guarddog:ref:refs/heads/v2
 
 claim_pattern:
   event_name: (push|workflow_dispatch)
-  job_workflow_ref: DataDog/guarddog/\.github/workflows/tag-release\.yml@refs/heads/main
-  ref: refs/heads/main
+  job_workflow_ref: DataDog/guarddog/\.github/workflows/tag-release\.yml@refs/heads/v2
+  ref: refs/heads/v2
   repository: DataDog/guarddog
 
 permissions:

--- a/.github/workflows/guarddog.yml
+++ b/.github/workflows/guarddog.yml
@@ -3,7 +3,7 @@ name: GuardDog
 on:
   pull_request:
     branches:
-      - main
+      - v2
       - v*
     paths:
       - 'requirements.txt'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,7 +3,7 @@ name: PR Checks
 on:
   pull_request:
     branches:
-      - main
+      - v2
       - v3
 
 permissions:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -2,7 +2,7 @@ name: OpenSSF Scorecard
 
 on:
   push:
-    branches: [main]
+    branches: [v3]
   schedule:
     - cron: '0 6 * * 1'
 

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [main, v3]
+    branches: [v2, v3]
   workflow_dispatch:
 
 permissions:
@@ -168,4 +168,5 @@ jobs:
             VERSION=${{ needs.package-validation.outputs.new_version }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.package-validation.outputs.new_version }}
-            ${{ github.ref_name == 'main' && format('{0}/{1}:latest', env.REGISTRY, env.IMAGE_NAME) || '' }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+            ${{ github.ref_name == 'v3' && format('{0}/{1}:latest', env.REGISTRY, env.IMAGE_NAME) || '' }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ If you found a bug, search if an issue already exists [search if an issue alread
 Create a new branch with the form: `<username>/<branch-function>`. After changing the repo locally and pushing to your branch's remote origin, create a pull request with a short description of your changes.
 
 ### Commit Signing
-All commits must be signed. The repository requires [commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on the `main` branch. Configure your local environment with GPG or SSH signing before pushing:
+All commits must be signed. The repository requires [commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on the `v2` and `v3` branches. Configure your local environment with GPG or SSH signing before pushing:
 
 ```sh
 # Using SSH signing (recommended)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12273/badge)](https://www.bestpractices.dev/projects/12273)
 
 <p align="center">
-  <img src="https://github.com/DataDog/guarddog/blob/main/docs/images/logo.png?raw=true" alt="GuardDog" width="300" />
+  <img src="https://github.com/DataDog/guarddog/blob/v3/docs/images/logo.png?raw=true" alt="GuardDog" width="300" />
 </p>
 
 GuardDog is a CLI tool that identifies malicious PyPI and npm packages, Go modules, GitHub actions, or VSCode extensions. It runs static analysis on package source code (through YARA rules) and analyzes package metadata to detect supply chain attacks.
@@ -263,7 +263,7 @@ jobs:
 
 Running all unit tests: `make test`
 
-Running unit tests against package metadata heuristics: `make test-metadata-rules` (tests are [here](https://github.com/DataDog/guarddog/tree/main/tests/analyzer/metadata)).
+Running unit tests against package metadata heuristics: `make test-metadata-rules` (tests are [here](https://github.com/DataDog/guarddog/tree/v3/tests/analyzer/metadata)).
 
 ### Benchmarking
 


### PR DESCRIPTION
## Summary

- Update branch triggers (`main` → `v2`) in `tag-release.yml`, `pr.yml`, `guarddog.yml`
- `scorecard.yml` now tracks `v3` (the new default branch)
- Replace Chainguard STS OIDC policy `self.github.tag-release.main` → `self.github.tag-release.v2`
- Docker image tagging: add `guarddog:<branch>` tag on every release; `:latest` now points to `v3` releases only
- Update `README.md` image URLs and `CONTRIBUTING.md` branch references to be self-contained on `v3`

## Test plan

- [ ] Merge freeze: apply after the `main` → `v2` rename is done in GitHub UI
- [ ] Open a PR targeting `v3` and confirm `pr.yml` checks trigger
- [ ] Bump version on `v3`, merge, confirm `tag-release.yml` fires and publishes `guarddog:v3` + `guarddog:latest` to GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)