### PR TITLE
Reject crafted ZIPs that scan empty but unpack code (#780)

### DIFF
--- a/guarddog/utils/archives.py
+++ b/guarddog/utils/archives.py
@@ -2,6 +2,7 @@ import logging
 import os
 import pathlib
 import stat
+import struct
 import zipfile
 
 import tarsafe  # type: ignore
@@ -37,6 +38,59 @@ def is_supported_archive(path: str) -> bool:
         return any(path.endswith(ext) for ext in [".zip", ".whl", ".egg"])
 
     return is_tar_archive(path) or is_zip_archive(path)
+
+
+_ZIP_LOCAL_FILE_HEADER = b"PK\x03\x04"
+
+
+def _count_local_file_headers(path: str) -> int:
+    """
+    Count members by walking the ZIP local file headers, independent of the
+    End-Of-Central-Directory record and central directory that zipfile trusts.
+
+    Each header is parsed for its compressed size so we can seek over the data
+    rather than scanning for the next signature (which would false-positive on
+    compressed bytes). Returns the number of headers walked. The walk stops
+    conservatively (undercounting) when a member cannot be followed cheaply: a
+    data descriptor with no inline sizes (general-purpose bit 3) or a ZIP64 size
+    marker. Undercounting is safe here; it only avoids false positives.
+    """
+    count = 0
+    with open(path, "rb") as f:
+        while True:
+            header = f.read(30)
+            if len(header) < 30 or header[:4] != _ZIP_LOCAL_FILE_HEADER:
+                break
+            flags = struct.unpack("<H", header[6:8])[0]
+            compressed_size = struct.unpack("<I", header[18:22])[0]
+            name_len = struct.unpack("<H", header[26:28])[0]
+            extra_len = struct.unpack("<H", header[28:30])[0]
+            if (flags & 0x08 and compressed_size == 0) or compressed_size == 0xFFFFFFFF:
+                break
+            f.seek(name_len + extra_len + compressed_size, os.SEEK_CUR)
+            count += 1
+    return count
+
+
+def _assert_zip_fully_enumerated(source_archive: str, enumerated: int) -> None:
+    """
+    Guard against ZIP parser-differential evasion (e.g. an End-Of-Central-Directory
+    record with size-of-central-directory set to 0, which makes zipfile read an
+    empty archive while installers still unpack the payload from the local file
+    headers). Raises if the local file headers expose more members than zipfile
+    enumerated from the central directory.
+
+    See https://github.com/DataDog/guarddog/issues/780 and the ZIP
+    parser-differential class described in USENIX Security 2025, "My ZIP isn't
+    your ZIP".
+    """
+    walked = _count_local_file_headers(source_archive)
+    if walked > enumerated:
+        raise ValueError(
+            f"archive parser anomaly: {walked} ZIP local file headers but zipfile "
+            f"enumerates {enumerated} members from the central directory "
+            f"(possible scan evasion via EOCD size/offset differential)"
+        )
 
 
 def safe_extract(
@@ -181,8 +235,15 @@ def safe_extract(
 
     elif zipfile.is_zipfile(source_archive):
         with zipfile.ZipFile(source_archive, "r") as zip_file:
+            members = zip_file.infolist()
+
+            # Reject archives where the central directory zipfile reads hides
+            # members that are still present as local file headers (and unpacked
+            # by installers). Otherwise such an archive scans as if it were empty.
+            _assert_zip_fully_enumerated(source_archive, len(members))
+
             # Check uncompressed size for zip archives
-            files = [info for info in zip_file.infolist() if not info.is_dir()]
+            files = [info for info in members if not info.is_dir()]
             file_count = len(files)
             total_size = sum(info.file_size for info in files)
 

--- a/guarddog/utils/archives.py
+++ b/guarddog/utils/archives.py
@@ -51,9 +51,12 @@ def _count_local_file_headers(path: str) -> int:
     Each header is parsed for its compressed size so we can seek over the data
     rather than scanning for the next signature (which would false-positive on
     compressed bytes). Returns the number of headers walked. The walk stops
-    conservatively (undercounting) when a member cannot be followed cheaply: a
-    data descriptor with no inline sizes (general-purpose bit 3) or a ZIP64 size
-    marker. Undercounting is safe here; it only avoids false positives.
+    conservatively (undercounting later members) when a member cannot be followed
+    cheaply: a data descriptor with no inline sizes (general-purpose bit 3) or a
+    ZIP64 size marker. The member at which the walk stops is still counted -- its
+    PK\x03\x04 signature positively identifies a real member -- so an archive with
+    an empty central directory but a non-empty payload is never undercounted to 0.
+    Undercounting later members is safe here; it only avoids false positives.
     """
     count = 0
     with open(path, "rb") as f:
@@ -61,6 +64,9 @@ def _count_local_file_headers(path: str) -> int:
             header = f.read(30)
             if len(header) < 30 or header[:4] != _ZIP_LOCAL_FILE_HEADER:
                 break
+            # A valid signature means we have positively found a member; count it
+            # before deciding whether the next one can be followed.
+            count += 1
             flags = struct.unpack("<H", header[6:8])[0]
             compressed_size = struct.unpack("<I", header[18:22])[0]
             name_len = struct.unpack("<H", header[26:28])[0]
@@ -68,7 +74,6 @@ def _count_local_file_headers(path: str) -> int:
             if (flags & 0x08 and compressed_size == 0) or compressed_size == 0xFFFFFFFF:
                 break
             f.seek(name_len + extra_len + compressed_size, os.SEEK_CUR)
-            count += 1
     return count
 
 

--- a/guarddog/utils/archives.py
+++ b/guarddog/utils/archives.py
@@ -41,59 +41,82 @@ def is_supported_archive(path: str) -> bool:
 
 
 _ZIP_LOCAL_FILE_HEADER = b"PK\x03\x04"
+_ZIP_EOCD_RECORD = b"PK\x05\x06"
 
 
-def _count_local_file_headers(path: str) -> int:
+def _count_local_file_headers(path: str, known_sizes: dict[int, int]) -> int:
     """
     Count members by walking the ZIP local file headers, independent of the
     End-Of-Central-Directory record and central directory that zipfile trusts.
 
-    Each header is parsed for its compressed size so we can seek over the data
-    rather than scanning for the next signature (which would false-positive on
-    compressed bytes). Returns the number of headers walked. The walk stops
-    conservatively (undercounting later members) when a member cannot be followed
-    cheaply: a data descriptor with no inline sizes (general-purpose bit 3) or a
-    ZIP64 size marker. The member at which the walk stops is still counted -- its
-    PK\x03\x04 signature positively identifies a real member -- so an archive with
-    an empty central directory but a non-empty payload is never undercounted to 0.
-    Undercounting later members is safe here; it only avoids false positives.
+    Each header's compressed size is used to seek over its payload rather than
+    scanning for the next signature (which would false-positive on compressed
+    bytes). When a header defers its size to a data descriptor (general-purpose
+    bit 3) or a ZIP64 marker, the size already known from the central directory
+    at that offset is used instead -- the central directory always carries the
+    final size, even for entries streamed with a data descriptor -- so the walk
+    keeps following members (skipping the trailing data descriptor too) instead
+    of stopping there. Only stops (undercounting, never overcounting) if no
+    central-directory size is known for that offset.
     """
     count = 0
     with open(path, "rb") as f:
         while True:
+            offset = f.tell()
             header = f.read(30)
             if len(header) < 30 or header[:4] != _ZIP_LOCAL_FILE_HEADER:
                 break
             # A valid signature means we have positively found a member; count it
             # before deciding whether the next one can be followed.
             count += 1
-            flags = struct.unpack("<H", header[6:8])[0]
-            compressed_size = struct.unpack("<I", header[18:22])[0]
-            name_len = struct.unpack("<H", header[26:28])[0]
-            extra_len = struct.unpack("<H", header[28:30])[0]
-            if (flags & 0x08 and compressed_size == 0) or compressed_size == 0xFFFFFFFF:
-                break
+            _, flags, _, _, _, _, compressed_size, _, name_len, extra_len = (
+                struct.unpack("<HHHHHIIIHH", header[4:30])
+            )
+            uses_data_descriptor = bool(flags & 0x08) and compressed_size == 0
+            if uses_data_descriptor or compressed_size == 0xFFFFFFFF:
+                known = known_sizes.get(offset)
+                if known is None:
+                    break
+                compressed_size = known
             f.seek(name_len + extra_len + compressed_size, os.SEEK_CUR)
+            if uses_data_descriptor:
+                # The payload is followed by a data descriptor: crc32 + sizes
+                # (12 bytes), optionally prefixed with a PK\x07\x08 signature
+                # (16 bytes total). Skip it so the next real header can be found.
+                marker = f.read(4)
+                f.seek(12 if marker == b"PK\x07\x08" else 8, os.SEEK_CUR)
     return count
 
 
-def _assert_zip_fully_enumerated(source_archive: str, enumerated: int) -> None:
+def _assert_zip_fully_enumerated(
+    source_archive: str, members: list[zipfile.ZipInfo]
+) -> None:
     """
-    Guard against ZIP parser-differential evasion (e.g. an End-Of-Central-Directory
-    record with size-of-central-directory set to 0, which makes zipfile read an
-    empty archive while installers still unpack the payload from the local file
-    headers). Raises if the local file headers expose more members than zipfile
-    enumerated from the central directory.
+    Guard against ZIP parser-differential evasion: an End-Of-Central-Directory
+    record with size-of-central-directory set to 0 (or similar) makes zipfile
+    read an empty archive while installers still unpack the payload from the
+    local file headers. Raises if the local file headers expose more members
+    than zipfile enumerated from the central directory, or if a second EOCD
+    record is present (which can redirect naive parsers to a different central
+    directory than the one validated here).
 
     See https://github.com/DataDog/guarddog/issues/780 and the ZIP
     parser-differential class described in USENIX Security 2025, "My ZIP isn't
     your ZIP".
     """
-    walked = _count_local_file_headers(source_archive)
-    if walked > enumerated:
+    with open(source_archive, "rb") as f:
+        if f.read().count(_ZIP_EOCD_RECORD) > 1:
+            raise ValueError(
+                "archive parser anomaly: multiple End-Of-Central-Directory records "
+                "(possible scan evasion via duplicate EOCD)"
+            )
+
+    known_sizes = {info.header_offset: info.compress_size for info in members}
+    walked = _count_local_file_headers(source_archive, known_sizes)
+    if walked > len(members):
         raise ValueError(
             f"archive parser anomaly: {walked} ZIP local file headers but zipfile "
-            f"enumerates {enumerated} members from the central directory "
+            f"enumerates {len(members)} members from the central directory "
             f"(possible scan evasion via EOCD size/offset differential)"
         )
 
@@ -245,7 +268,7 @@ def safe_extract(
             # Reject archives where the central directory zipfile reads hides
             # members that are still present as local file headers (and unpacked
             # by installers). Otherwise such an archive scans as if it were empty.
-            _assert_zip_fully_enumerated(source_archive, len(members))
+            _assert_zip_fully_enumerated(source_archive, members)
 
             # Check uncompressed size for zip archives
             files = [info for info in members if not info.is_dir()]

--- a/tests/core/test_archives.py
+++ b/tests/core/test_archives.py
@@ -1,6 +1,7 @@
 import binascii
 import os
 import struct
+import zipfile
 
 import pytest
 
@@ -12,12 +13,21 @@ PLAIN_TARGZ = os.path.join(FIXTURES, "plain.tar.gz")
 ZIP_PASSWORD = b"hunter2"
 
 
-def _build_zip(members: dict[str, bytes], cd_size: int | None = None) -> bytes:
+def _build_zip(
+    members: dict[str, bytes],
+    cd_size: int | None = None,
+    data_descriptor: bool = False,
+) -> bytes:
     """
     Build a stored (uncompressed) ZIP by hand so the End-Of-Central-Directory
     size-of-central-directory field can be overridden. With ``cd_size=0`` the
     archive reproduces the parser-differential from issue #780: zipfile reads it
     as empty while the local file headers still carry every member.
+
+    When ``data_descriptor`` is set, each local file header sets general-purpose
+    bit 3 and zeroes its inline sizes/crc, deferring them to a trailing data
+    descriptor (PK\\x07\\x08). The local-header walk cannot follow past such an
+    entry, which exercises the "count before bailing out" path of the guard.
     """
     body = bytearray()
     central = bytearray()
@@ -26,6 +36,13 @@ def _build_zip(members: dict[str, bytes], cd_size: int | None = None) -> bytes:
         raw = name.encode()
         crc = binascii.crc32(data) & 0xFFFFFFFF
         offsets.append(len(body))
+        if data_descriptor:
+            body += b"PK\x03\x04" + struct.pack(
+                "<HHHHHIIIHH", 20, 0x08, 0, 0, 0x21, 0, 0, 0, len(raw), 0
+            )
+            body += raw + data
+            body += b"PK\x07\x08" + struct.pack("<III", crc, len(data), len(data))
+            continue
         body += b"PK\x03\x04" + struct.pack(
             "<HHHHHIIIHH", 20, 0, 0, 0, 0x21, crc, len(data), len(data), len(raw), 0
         )
@@ -109,9 +126,23 @@ def test_cd_size_zero_eocd_differential_rejected(tmp_path):
     archive = tmp_path / "crafted-1.0-py3-none-any.whl"
     archive.write_bytes(_build_zip(_WHL_MEMBERS, cd_size=0))
 
-    import zipfile
+    with zipfile.ZipFile(str(archive)) as zf:
+        assert zf.namelist() == []
 
-    assert zipfile.ZipFile(str(archive)).namelist() == []
+    with pytest.raises(ValueError, match="parser anomaly"):
+        safe_extract(str(archive), str(tmp_path / "out"))
+
+
+def test_cd_size_zero_with_data_descriptor_rejected(tmp_path):
+    # Same EOCD differential as above, but the first local header uses a data
+    # descriptor (general-purpose bit 3, sizes deferred to a trailing record).
+    # The walk cannot follow past such an entry, yet it must still count it so the
+    # "empty central directory but non-empty payload" anomaly is rejected (#780).
+    archive = tmp_path / "crafted-dd-1.0-py3-none-any.whl"
+    archive.write_bytes(_build_zip(_WHL_MEMBERS, cd_size=0, data_descriptor=True))
+
+    with zipfile.ZipFile(str(archive)) as zf:
+        assert zf.namelist() == []
 
     with pytest.raises(ValueError, match="parser anomaly"):
         safe_extract(str(archive), str(tmp_path / "out"))

--- a/tests/core/test_archives.py
+++ b/tests/core/test_archives.py
@@ -1,4 +1,6 @@
+import binascii
 import os
+import struct
 
 import pytest
 
@@ -8,6 +10,67 @@ FIXTURES = os.path.join(os.path.dirname(__file__), "resources", "archives")
 ENCRYPTED_ZIP = os.path.join(FIXTURES, "encrypted.zip")
 PLAIN_TARGZ = os.path.join(FIXTURES, "plain.tar.gz")
 ZIP_PASSWORD = b"hunter2"
+
+
+def _build_zip(members: dict[str, bytes], cd_size: int | None = None) -> bytes:
+    """
+    Build a stored (uncompressed) ZIP by hand so the End-Of-Central-Directory
+    size-of-central-directory field can be overridden. With ``cd_size=0`` the
+    archive reproduces the parser-differential from issue #780: zipfile reads it
+    as empty while the local file headers still carry every member.
+    """
+    body = bytearray()
+    central = bytearray()
+    offsets = []
+    for name, data in members.items():
+        raw = name.encode()
+        crc = binascii.crc32(data) & 0xFFFFFFFF
+        offsets.append(len(body))
+        body += b"PK\x03\x04" + struct.pack(
+            "<HHHHHIIIHH", 20, 0, 0, 0, 0x21, crc, len(data), len(data), len(raw), 0
+        )
+        body += raw + data
+    real_cd_size = 0
+    for (name, data), offset in zip(members.items(), offsets):
+        raw = name.encode()
+        crc = binascii.crc32(data) & 0xFFFFFFFF
+        record = (
+            b"PK\x01\x02"
+            + struct.pack(
+                "<HHHHHHIIIHHHHHII",
+                20,
+                20,
+                0,
+                0,
+                0,
+                0x21,
+                crc,
+                len(data),
+                len(data),
+                len(raw),
+                0,
+                0,
+                0,
+                0,
+                (0o100644) << 16,
+                offset,
+            )
+            + raw
+        )
+        central += record
+        real_cd_size += len(record)
+    count = len(members)
+    eocd_cd_size = real_cd_size if cd_size is None else cd_size
+    eocd = b"PK\x05\x06" + struct.pack(
+        "<HHHHIIH", 0, 0, count, count, eocd_cd_size, len(body), 0
+    )
+    return bytes(body) + bytes(central) + eocd
+
+
+_WHL_MEMBERS = {
+    "pkg/__init__.py": b"print('hello')\n",
+    "pkg-1.0.dist-info/METADATA": b"Metadata-Version: 2.1\nName: pkg\nVersion: 1.0\n",
+}
 
 
 def test_encrypted_zip_extracts_with_correct_password(tmp_path):
@@ -29,3 +92,26 @@ def test_encrypted_zip_wrong_password_raises(tmp_path):
 def test_tar_archive_rejects_password(tmp_path):
     with pytest.raises(ValueError, match="only supported for ZIP"):
         safe_extract(PLAIN_TARGZ, str(tmp_path), zip_password=ZIP_PASSWORD)
+
+
+def test_well_formed_zip_extracts(tmp_path):
+    archive = tmp_path / "pkg-1.0-py3-none-any.whl"
+    archive.write_bytes(_build_zip(_WHL_MEMBERS))
+    out = tmp_path / "out"
+    out.mkdir()
+    safe_extract(str(archive), str(out))
+    assert (out / "pkg" / "__init__.py").read_bytes() == _WHL_MEMBERS["pkg/__init__.py"]
+
+
+def test_cd_size_zero_eocd_differential_rejected(tmp_path):
+    # zipfile reads this as empty (namelist() == []) but the payload is still
+    # present in the local file headers; safe_extract must refuse it (issue #780).
+    archive = tmp_path / "crafted-1.0-py3-none-any.whl"
+    archive.write_bytes(_build_zip(_WHL_MEMBERS, cd_size=0))
+
+    import zipfile
+
+    assert zipfile.ZipFile(str(archive)).namelist() == []
+
+    with pytest.raises(ValueError, match="parser anomaly"):
+        safe_extract(str(archive), str(tmp_path / "out"))

--- a/tests/core/test_archives.py
+++ b/tests/core/test_archives.py
@@ -17,6 +17,7 @@ def _build_zip(
     members: dict[str, bytes],
     cd_size: int | None = None,
     data_descriptor: bool = False,
+    extra_body: bytes = b"",
 ) -> bytes:
     """
     Build a stored (uncompressed) ZIP by hand so the End-Of-Central-Directory
@@ -28,6 +29,10 @@ def _build_zip(
     bit 3 and zeroes its inline sizes/crc, deferring them to a trailing data
     descriptor (PK\\x07\\x08). The local-header walk cannot follow past such an
     entry, which exercises the "count before bailing out" path of the guard.
+
+    ``extra_body`` is appended after the real members and before the central
+    directory: bytes present as a local file header but never described by
+    any central directory record.
     """
     body = bytearray()
     central = bytearray()
@@ -47,6 +52,7 @@ def _build_zip(
             "<HHHHHIIIHH", 20, 0, 0, 0, 0x21, crc, len(data), len(data), len(raw), 0
         )
         body += raw + data
+    body += extra_body
     real_cd_size = 0
     for (name, data), offset in zip(members.items(), offsets):
         raw = name.encode()
@@ -128,6 +134,60 @@ def test_cd_size_zero_eocd_differential_rejected(tmp_path):
 
     with zipfile.ZipFile(str(archive)) as zf:
         assert zf.namelist() == []
+
+    with pytest.raises(ValueError, match="parser anomaly"):
+        safe_extract(str(archive), str(tmp_path / "out"))
+
+
+def test_data_descriptor_decoy_hides_extra_member_rejected(tmp_path):
+    # One legitimate member uses a data descriptor and matches the central
+    # directory (walked == enumerated == 1), but a second, real local file
+    # header follows it that the central directory never mentions. The walker
+    # must use the central directory's known size to keep going past the
+    # data-descriptor entry and catch the hidden member instead of stopping.
+    hidden_name = b"pkg/evil.py"
+    hidden_data = b"import os\n"
+    hidden_header = b"PK\x03\x04" + struct.pack(
+        "<HHHHHIIIHH",
+        20,
+        0,
+        0,
+        0,
+        0x21,
+        binascii.crc32(hidden_data) & 0xFFFFFFFF,
+        len(hidden_data),
+        len(hidden_data),
+        len(hidden_name),
+        0,
+    )
+    archive = tmp_path / "crafted-dd-hidden-1.0-py3-none-any.whl"
+    archive.write_bytes(
+        _build_zip(
+            {"pkg/__init__.py": _WHL_MEMBERS["pkg/__init__.py"]},
+            data_descriptor=True,
+            extra_body=hidden_header + hidden_name + hidden_data,
+        )
+    )
+
+    with zipfile.ZipFile(str(archive)) as zf:
+        assert zf.namelist() == ["pkg/__init__.py"]
+
+    with pytest.raises(ValueError, match="parser anomaly"):
+        safe_extract(str(archive), str(tmp_path / "out"))
+
+
+def test_duplicate_eocd_rejected(tmp_path):
+    # An extra EOCD-shaped signature ahead of the real one (still correctly
+    # parsed by zipfile, since the real central directory offset accounts for
+    # it) is exactly the kind of ambiguity a second EOCD record introduces:
+    # some parsers could latch onto the wrong one.
+    archive = tmp_path / "crafted-dup-eocd-1.0-py3-none-any.whl"
+    archive.write_bytes(
+        _build_zip(_WHL_MEMBERS, extra_body=b"PK\x05\x06" + b"\x00" * 18)
+    )
+
+    with zipfile.ZipFile(str(archive)) as zf:
+        assert zf.namelist() == list(_WHL_MEMBERS)
 
     with pytest.raises(ValueError, match="parser anomaly"):
         safe_extract(str(archive), str(tmp_path / "out"))


### PR DESCRIPTION
Fixes #780.

While looking at how guarddog reads wheels I noticed it trusts whatever `zipfile` enumerates from the central directory. You can craft an archive where that view is empty but the payload is still there:

- set the EOCD `size of central directory` to `0`
- or append a second EOCD record with 0 entries
- or point `cd_offset` at an empty central directory

In all of these `zipfile.namelist()` comes back empty, so `safe_extract` pulls out zero files and the package scans as clean ("Found 0 potentially malicious indicators") - even though pip and other installers happily unpack the code from the local file headers.

What I changed in `safe_extract`: before extracting, walk the local file headers directly and refuse the archive if there are more of them than zipfile enumerated. I parse each header's compressed size and seek over the data rather than scanning for the `PK` signature, because a raw signature scan false-positives on compressed bytes. The walk stops early on data descriptors without inline sizes and on zip64 size markers, so it can only ever undercount - it won't reject a legit archive.

Tests in `tests/core/test_archives.py`:
- a normal stored wheel still extracts
- the `cd_size=0` archive (`namelist() == []`) now raises

I also checked the trailing-EOCD framing and ran it against a real deflate wheel with 107 members including a directory entry - no false positive there. `make lint` and `black --check guarddog` pass, mypy has nothing new on `archives.py`.

Background on this bug class is the USENIX Security 2025 paper "My ZIP isn't your ZIP": https://www.usenix.org/system/files/usenixsecurity25-you.pdf

One note - my commit isn't signed and v3 looks like it requires signed commits, so a squash merge would probably be easiest on your end. Happy to adjust anything.