### PR TITLE
Fix sandbox in docker

### DIFF
--- a/guarddog/sandbox.py
+++ b/guarddog/sandbox.py
@@ -139,6 +139,16 @@ def _get_common_read_paths() -> list[str]:
 
     candidates = [sys.prefix, sys.base_prefix, "/usr", "/lib"]
 
+    # SSL certificate directories: pygit2 initializes OpenSSL at import time and
+    # reads the system CA bundle. On Linux (Landlock), only explicitly listed paths
+    # are readable — unlike macOS (Seatbelt) which includes system paths by default.
+    import ssl
+
+    verify_paths = ssl.get_default_verify_paths()
+    for cert_path in (verify_paths.cafile, verify_paths.capath):
+        if cert_path:
+            candidates.append(os.path.dirname(cert_path) if os.path.isfile(cert_path) else cert_path)
+
     # guarddog package dir: needed for YARA rule files, which may
     # live outside sys.prefix when running from source (e.g. uv run)
     import guarddog

--- a/guarddog/sandbox.py
+++ b/guarddog/sandbox.py
@@ -147,7 +147,9 @@ def _get_common_read_paths() -> list[str]:
     verify_paths = ssl.get_default_verify_paths()
     for cert_path in (verify_paths.cafile, verify_paths.capath):
         if cert_path:
-            candidates.append(os.path.dirname(cert_path) if os.path.isfile(cert_path) else cert_path)
+            candidates.append(
+                os.path.dirname(cert_path) if os.path.isfile(cert_path) else cert_path
+            )
 
     # guarddog package dir: needed for YARA rule files, which may
     # live outside sys.prefix when running from source (e.g. uv run)


### PR DESCRIPTION
Getting this error in debian docker
```
root@7fcdefd75e37:/# guarddog pypi scan requests
No risks found in requests

Some rules failed to run while scanning requests:

* download-package: Sandboxed extraction failed: Traceback (most recent call last):
  File "<frozen runpy>", line 189, in _run_module_as_main
  File "<frozen runpy>", line 112, in _get_module_details
  File "/usr/local/lib/python3.12/site-packages/guarddog/__init__.py", line 1, in <module>
    from guarddog.scanners.npm_package_scanner import NPMPackageScanner  # NOQA
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/guarddog/scanners/__init__.py", line 3, in <module>
    from .github_action_project_scanner import GitHubActionDependencyScanner
  File "/usr/local/lib/python3.12/site-packages/guarddog/scanners/github_action_project_scanner.py", line 14, in <module>
    from guarddog.scanners.github_action_scanner import GithubActionScanner
  File "/usr/local/lib/python3.12/site-packages/guarddog/scanners/github_action_scanner.py", line 7, in <module>
    from guarddog.analyzer.analyzer import Analyzer
  File "/usr/local/lib/python3.12/site-packages/guarddog/analyzer/analyzer.py", line 10, in <module>
    from guarddog.analyzer.metadata import get_metadata_detectors
  File "/usr/local/lib/python3.12/site-packages/guarddog/analyzer/metadata/__init__.py", line 3, in <module>
    from guarddog.analyzer.metadata.pypi import PYPI_METADATA_RULES
  File "/usr/local/lib/python3.12/site-packages/guarddog/analyzer/metadata/pypi/__init__.py", line 7, in <module>
    from guarddog.analyzer.metadata.pypi.repository_integrity_mismatch import (
  File "/usr/local/lib/python3.12/site-packages/guarddog/analyzer/metadata/pypi/repository_integrity_mismatch.py", line 15, in <module>
    from guarddog.analyzer.metadata.repository_integrity_mismatch import IntegrityMismatch
  File "/usr/local/lib/python3.12/site-packages/guarddog/analyzer/metadata/repository_integrity_mismatch.py", line 7, in <module>
    import pygit2
  File "/usr/local/lib/python3.12/site-packages/pygit2/__init__.py", line 549, in <module>
    settings = Settings()
               ^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pygit2/settings.py", line 60, in __init__
    self._initialize_tls_certificate_locations()
  File "/usr/local/lib/python3.12/site-packages/pygit2/settings.py", line 66, in _initialize_tls_certificate_locations
    self.set_ssl_cert_locations(
  File "/usr/local/lib/python3.12/site-packages/pygit2/settings.py", line 216, in set_ssl_cert_locations
    option(Option.SET_SSL_CERT_LOCATIONS, cert_file, cert_dir)
  File "/usr/local/lib/python3.12/site-packages/pygit2/options.py", line 437, in option
    check_error(err)
  File "/usr/local/lib/python3.12/site-packages/pygit2/errors.py", line 67, in check_error
    raise GitError(message)
_pygit2.GitError: OpenSSL error: failed to load certificates: error:8000000D:system library::Permission 
```