### PR TITLE
Show PyPI Inspector link for remote PyPI findings

### DIFF
--- a/guarddog/cli.py
+++ b/guarddog/cli.py
@@ -10,7 +10,7 @@ import shutil
 import sys
 import tempfile
 from typing import Optional
-from urllib.parse import urlparse, unquote
+from urllib.parse import quote, urlparse, unquote
 
 import click
 import requests
@@ -358,6 +358,7 @@ def _scan(
                 )
             else:
                 result |= scanner.scan_remote(identifier, version, rule_param)
+            _add_pypi_inspector_url(result, identifier, ecosystem)
 
     except Exception as e:
         log.error(f"Error occurred while scanning target {identifier}: '{e}'\n")
@@ -370,6 +371,21 @@ def _scan(
 
     if exit_non_zero_on_finding:
         exit_with_status_code([result])
+
+
+def _add_pypi_inspector_url(result: dict, identifier: str, ecosystem: ECOSYSTEM):
+    if ecosystem != ECOSYSTEM.PYPI or result.get("issues", 0) < 1:
+        return
+
+    package_version = result.get("package_version")
+    if package_version is None:
+        return
+
+    package = quote(identifier, safe="")
+    version = quote(str(package_version), safe="")
+    result["pypi_inspector_url"] = (
+        f"https://inspector.pypi.io/project/{package}/{version}/"
+    )
 
 
 def _scan_remote_sandboxed(scanner, name, version, rules):
@@ -443,7 +459,7 @@ def _scan_remote_sandboxed(scanner, name, version, rules):
             }
             for risk in risk_objects
         ]
-        return {
+        results = {
             "issues": metadata_results["issues"] + sourcecode_results["issues"],
             "errors": metadata_results["errors"] | sourcecode_results["errors"],
             "results": metadata_results["results"] | sourcecode_results["results"],
@@ -451,6 +467,10 @@ def _scan_remote_sandboxed(scanner, name, version, rules):
             "risk_score": risk_score,
             "risks": formatted_risks,
         }
+        scanned_version = scanner.get_package_version(package_info, version)
+        if scanned_version is not None:
+            results["package_version"] = scanned_version
+        return results
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
 

--- a/guarddog/cli.py
+++ b/guarddog/cli.py
@@ -470,6 +470,9 @@ def _scan_remote_sandboxed(scanner, name, version, rules):
         scanned_version = scanner.get_package_version(package_info, version)
         if scanned_version is not None:
             results["package_version"] = scanned_version
+        dist_path = scanner.get_package_dist_path(package_info, version)
+        if dist_path is not None:
+            results["pypi_dist_path"] = dist_path
         return results
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)

--- a/guarddog/cli.py
+++ b/guarddog/cli.py
@@ -10,7 +10,7 @@ import shutil
 import sys
 import tempfile
 from typing import Optional
-from urllib.parse import quote, urlparse, unquote
+from urllib.parse import urlparse, unquote
 
 import click
 import requests
@@ -358,7 +358,6 @@ def _scan(
                 )
             else:
                 result |= scanner.scan_remote(identifier, version, rule_param)
-            _add_pypi_inspector_url(result, identifier, ecosystem)
 
     except Exception as e:
         log.error(f"Error occurred while scanning target {identifier}: '{e}'\n")
@@ -371,21 +370,6 @@ def _scan(
 
     if exit_non_zero_on_finding:
         exit_with_status_code([result])
-
-
-def _add_pypi_inspector_url(result: dict, identifier: str, ecosystem: ECOSYSTEM):
-    if ecosystem != ECOSYSTEM.PYPI or result.get("issues", 0) < 1:
-        return
-
-    package_version = result.get("package_version")
-    if package_version is None:
-        return
-
-    package = quote(identifier, safe="")
-    version = quote(str(package_version), safe="")
-    result["pypi_inspector_url"] = (
-        f"https://inspector.pypi.io/project/{package}/{version}/"
-    )
 
 
 def _scan_remote_sandboxed(scanner, name, version, rules):
@@ -467,12 +451,7 @@ def _scan_remote_sandboxed(scanner, name, version, rules):
             "risk_score": risk_score,
             "risks": formatted_risks,
         }
-        scanned_version = scanner.get_package_version(package_info, version)
-        if scanned_version is not None:
-            results["package_version"] = scanned_version
-        dist_path = scanner.get_package_dist_path(package_info, version)
-        if dist_path is not None:
-            results["pypi_dist_path"] = dist_path
+        scanner._annotate_remote_results(results, package_info, name, version)
         return results
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)

--- a/guarddog/reporters/human_readable.py
+++ b/guarddog/reporters/human_readable.py
@@ -306,6 +306,17 @@ class HumanReadableReporter(BaseReporter):
         ]
 
     @staticmethod
+    def _format_pypi_inspector_url(results: dict) -> List[str]:
+        inspector_url = results.get("pypi_inspector_url")
+        if not inspector_url or results.get("issues", 0) < 1:
+            return []
+
+        return [
+            "",
+            colored("Package files:", "dark_grey") + f" {_sanitize(inspector_url)}",
+        ]
+
+    @staticmethod
     def _format_header(identifier: str, num_risks: int) -> List[str]:
         bold = colored(_sanitize(identifier), None, attrs=["bold"])
         if num_risks == 0:
@@ -337,6 +348,7 @@ class HumanReadableReporter(BaseReporter):
         lines += HumanReadableReporter._format_header(identifier, len(risks))
         if risks:
             lines += HumanReadableReporter._format_findings(risks, path_prefix, ceiling)
+        lines += HumanReadableReporter._format_pypi_inspector_url(results)
         if risk_score:
             lines += HumanReadableReporter._format_summary(risk_score, len(risks))
 

--- a/guarddog/reporters/human_readable.py
+++ b/guarddog/reporters/human_readable.py
@@ -1,6 +1,7 @@
 import os
 import re
 from enum import Enum
+from urllib.parse import quote
 
 from termcolor import colored
 from guarddog.reporters import BaseReporter
@@ -201,7 +202,10 @@ class HumanReadableReporter(BaseReporter):
 
     @staticmethod
     def _format_one_risk(
-        risk: dict, path_prefix: Optional[str], ceiling: str | None
+        risk: dict,
+        path_prefix: Optional[str],
+        ceiling: str | None,
+        deep_base: Optional[str] = None,
     ) -> List[str]:
         """Render a single risk as a railed block: rule, desc, location, code.
 
@@ -227,7 +231,16 @@ class HumanReadableReporter(BaseReporter):
         ]
         if desc:
             block.append("  " + colored(desc, sev_color))
-        block.append("  " + colored(f"{loc_kw} {_sanitize(loc)}", "dark_grey"))
+
+        inspector_url = (
+            HumanReadableReporter._pypi_finding_inspector_url(deep_base, loc_raw)
+            if deep_base and loc_raw
+            else None
+        )
+        loc_line = colored(f"{loc_kw} {_sanitize(loc)}", "dark_grey")
+        if inspector_url:
+            loc_line = HumanReadableReporter._hyperlink(inspector_url, loc_line)
+        block.append("  " + loc_line)
 
         code = risk.get("threat_code", "")
         if code:
@@ -244,7 +257,10 @@ class HumanReadableReporter(BaseReporter):
 
     @staticmethod
     def _format_findings(
-        risks: list, path_prefix: Optional[str], ceiling: str | None
+        risks: list,
+        path_prefix: Optional[str],
+        ceiling: str | None,
+        deep_base: Optional[str] = None,
     ) -> List[str]:
         """Per-tactic findings list, colored by rule severity clamped to the band."""
         lines: List[str] = []
@@ -278,7 +294,7 @@ class HumanReadableReporter(BaseReporter):
 
                 for risk in tactic_risks:
                     lines += HumanReadableReporter._format_one_risk(
-                        risk, path_prefix, ceiling
+                        risk, path_prefix, ceiling, deep_base
                     )
 
                 lines.append("")
@@ -306,14 +322,59 @@ class HumanReadableReporter(BaseReporter):
         ]
 
     @staticmethod
+    def _hyperlink(url: str, label: str) -> str:
+        """Wrap `label` in an OSC 8 terminal hyperlink pointing to `url`.
+
+        Terminals that support OSC 8 render `label` as a clickable link; the rest
+        ignore the escape wrapper and show `label` unchanged. `url` must be free of
+        terminal control bytes, otherwise a crafted value could break out of the
+        escape sequence, so we fall back to the bare label when it isn't.
+        """
+        if _TERMINAL_CONTROL_RE.search(url):
+            return label
+        return f"\x1b]8;;{url}\x1b\\{label}\x1b]8;;\x1b\\"
+
+    @staticmethod
+    def _pypi_deep_link_base(results: dict) -> Optional[str]:
+        """Base for per-finding PyPI Inspector links, or None when unavailable.
+
+        Combines the project URL (already carries the escaped package/version) with
+        the scanned distribution's `/packages/...` path, giving a prefix that only
+        needs the in-archive file path and `#line.N` appended.
+        """
+        inspector_url = results.get("pypi_inspector_url")
+        dist_path = results.get("pypi_dist_path")
+        if not inspector_url or not dist_path or results.get("issues", 0) < 1:
+            return None
+        return inspector_url.rstrip("/") + dist_path
+
+    @staticmethod
+    def _pypi_finding_inspector_url(
+        deep_base: str, threat_location: str
+    ) -> Optional[str]:
+        """Deep link to a finding's file and line on PyPI Inspector.
+
+        `threat_location` is `<relpath-in-archive>:<line>`, relative to the extract
+        root, which is exactly the path Inspector expects after the distribution
+        filename.
+        """
+        file_part, _, line = threat_location.rpartition(":")
+        if not file_part or not line.isdigit():
+            return None
+        return f"{deep_base}/{quote(file_part, safe='/')}#line.{line}"
+
+    @staticmethod
     def _format_pypi_inspector_url(results: dict) -> List[str]:
         inspector_url = results.get("pypi_inspector_url")
         if not inspector_url or results.get("issues", 0) < 1:
             return []
 
+        link = HumanReadableReporter._hyperlink(
+            inspector_url, colored("view on PyPI Inspector", "dark_grey")
+        )
         return [
             "",
-            colored("Package files:", "dark_grey") + f" {_sanitize(inspector_url)}",
+            colored("Package files:", "dark_grey") + f" {link}",
         ]
 
     @staticmethod
@@ -344,10 +405,14 @@ class HumanReadableReporter(BaseReporter):
         )
         ceiling = HumanReadableReporter._BAND_CEILING.get(label)
 
+        deep_base = HumanReadableReporter._pypi_deep_link_base(results)
+
         lines: List[str] = []
         lines += HumanReadableReporter._format_header(identifier, len(risks))
         if risks:
-            lines += HumanReadableReporter._format_findings(risks, path_prefix, ceiling)
+            lines += HumanReadableReporter._format_findings(
+                risks, path_prefix, ceiling, deep_base
+            )
         lines += HumanReadableReporter._format_pypi_inspector_url(results)
         if risk_score:
             lines += HumanReadableReporter._format_summary(risk_score, len(risks))

--- a/guarddog/scanners/pypi_package_scanner.py
+++ b/guarddog/scanners/pypi_package_scanner.py
@@ -18,6 +18,11 @@ class PypiPackageScanner(PackageScanner):
         extract_dir = self.download_package(package_name, directory, version)
         return get_package_info(package_name), extract_dir
 
+    def get_package_version(self, package_info: dict, requested_version=None):
+        if requested_version is not None:
+            return requested_version
+        return package_info.get("info", {}).get("version")
+
     def download_package(self, package_name, directory, version=None) -> str:
         """Downloads the PyPI distribution for a given package and version
 

--- a/guarddog/scanners/pypi_package_scanner.py
+++ b/guarddog/scanners/pypi_package_scanner.py
@@ -1,6 +1,6 @@
 import os
 import typing
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 from guarddog.analyzer.analyzer import Analyzer
 from guarddog.ecosystems import ECOSYSTEM
@@ -40,6 +40,11 @@ class PypiPackageScanner(PackageScanner):
         if distribution is None:
             return None
         return urlparse(distribution["url"]).path
+
+    def get_package_inspector_url(self, name, version):
+        package = quote(name, safe="")
+        version = quote(str(version), safe="")
+        return f"https://inspector.pypi.io/project/{package}/{version}/"
 
     def download_package(self, package_name, directory, version=None) -> str:
         """Downloads the PyPI distribution for a given package and version

--- a/guarddog/scanners/pypi_package_scanner.py
+++ b/guarddog/scanners/pypi_package_scanner.py
@@ -1,5 +1,6 @@
 import os
 import typing
+from urllib.parse import urlparse
 
 from guarddog.analyzer.analyzer import Analyzer
 from guarddog.ecosystems import ECOSYSTEM
@@ -22,6 +23,23 @@ class PypiPackageScanner(PackageScanner):
         if requested_version is not None:
             return requested_version
         return package_info.get("info", {}).get("version")
+
+    @staticmethod
+    def _select_distribution(package_info: dict, version) -> typing.Optional[dict]:
+        """Return the release file GuardDog scans for a version (first supported archive)."""
+        releases = package_info.get("releases", {})
+        if version is None:
+            version = package_info.get("info", {}).get("version")
+        for file in releases.get(version, []):
+            if is_supported_archive(file["filename"]):
+                return file
+        return None
+
+    def get_package_dist_path(self, package_info: dict, requested_version=None):
+        distribution = self._select_distribution(package_info, requested_version)
+        if distribution is None:
+            return None
+        return urlparse(distribution["url"]).path
 
     def download_package(self, package_name, directory, version=None) -> str:
         """Downloads the PyPI distribution for a given package and version
@@ -51,19 +69,14 @@ class PypiPackageScanner(PackageScanner):
                 f"Version {version} for package {package_name} doesn't exist."
             )
 
-        files = releases[version]
-        url, file_extension = None, None
-
-        for file in files:
-            if is_supported_archive(file["filename"]):
-                url = file["url"]
-                _, file_extension = os.path.splitext(file["filename"])
-                break
-
-        if not (url and file_extension):
+        distribution = self._select_distribution(data, version)
+        if distribution is None:
             raise Exception(
                 f"Compressed file for {package_name} does not exist on PyPI."
             )
+
+        url = distribution["url"]
+        _, file_extension = os.path.splitext(distribution["filename"])
 
         # Path to compressed package
         zippath = os.path.join(directory, package_name + file_extension)

--- a/guarddog/scanners/scanner.py
+++ b/guarddog/scanners/scanner.py
@@ -217,6 +217,9 @@ class PackageScanner:
     ) -> typing.Tuple[dict, str]:
         raise NotImplementedError("download_and_get_package_info is not implemented")
 
+    def get_package_version(self, package_info: dict, requested_version=None):
+        return requested_version
+
     def _scan_remote(
         self, name, base_dir, version=None, rules=None, write_package_info=False
     ):
@@ -233,6 +236,9 @@ class PackageScanner:
             return {"issues": 0, "errors": {"download-package": str(e)}}
 
         results = self.analyzer.analyze(file_path, package_info, rules, name, version)
+        scanned_version = self.get_package_version(package_info, version)
+        if scanned_version is not None:
+            results["package_version"] = scanned_version
         if write_package_info:
             package_name = name.replace("/", "-")
             suffix = (

--- a/guarddog/scanners/scanner.py
+++ b/guarddog/scanners/scanner.py
@@ -220,6 +220,13 @@ class PackageScanner:
     def get_package_version(self, package_info: dict, requested_version=None):
         return requested_version
 
+    def get_package_dist_path(self, package_info: dict, requested_version=None):
+        """Return the PyPI-style `/packages/...` path of the scanned distribution.
+
+        Used to build PyPI Inspector deep links. Only PyPI packages have one.
+        """
+        return None
+
     def _scan_remote(
         self, name, base_dir, version=None, rules=None, write_package_info=False
     ):
@@ -239,6 +246,9 @@ class PackageScanner:
         scanned_version = self.get_package_version(package_info, version)
         if scanned_version is not None:
             results["package_version"] = scanned_version
+        dist_path = self.get_package_dist_path(package_info, version)
+        if dist_path is not None:
+            results["pypi_dist_path"] = dist_path
         if write_package_info:
             package_name = name.replace("/", "-")
             suffix = (

--- a/guarddog/scanners/scanner.py
+++ b/guarddog/scanners/scanner.py
@@ -227,6 +227,28 @@ class PackageScanner:
         """
         return None
 
+    def get_package_inspector_url(self, name, version) -> typing.Optional[str]:
+        """URL to the package's files on PyPI Inspector, or None if unsupported."""
+        return None
+
+    def _annotate_remote_results(self, results, package_info, name, version):
+        """Attach PyPI Inspector metadata to a remote scan's results.
+
+        Shared by the plain and sandboxed remote scan paths so direct scans and
+        `verify` project scans surface the same version, distribution path, and
+        Inspector links.
+        """
+        scanned_version = self.get_package_version(package_info, version)
+        if scanned_version is not None:
+            results["package_version"] = scanned_version
+            if results.get("issues", 0) >= 1:
+                inspector_url = self.get_package_inspector_url(name, scanned_version)
+                if inspector_url is not None:
+                    results["pypi_inspector_url"] = inspector_url
+        dist_path = self.get_package_dist_path(package_info, version)
+        if dist_path is not None:
+            results["pypi_dist_path"] = dist_path
+
     def _scan_remote(
         self, name, base_dir, version=None, rules=None, write_package_info=False
     ):
@@ -243,12 +265,7 @@ class PackageScanner:
             return {"issues": 0, "errors": {"download-package": str(e)}}
 
         results = self.analyzer.analyze(file_path, package_info, rules, name, version)
-        scanned_version = self.get_package_version(package_info, version)
-        if scanned_version is not None:
-            results["package_version"] = scanned_version
-        dist_path = self.get_package_dist_path(package_info, version)
-        if dist_path is not None:
-            results["pypi_dist_path"] = dist_path
+        self._annotate_remote_results(results, package_info, name, version)
         if write_package_info:
             package_name = name.replace("/", "-")
             suffix = (

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -52,6 +52,31 @@ class TestCli(unittest.TestCase):
         rules = guarddog.cli._get_rule_param((), (), ECOSYSTEM.PYPI)
         assert rules is None
 
+    def test_add_pypi_inspector_url_for_pypi_scan_with_findings(self):
+        results = {"issues": 1, "package_version": "2.28.1"}
+        guarddog.cli._add_pypi_inspector_url(results, "requests", ECOSYSTEM.PYPI)
+        assert (
+            results["pypi_inspector_url"]
+            == "https://inspector.pypi.io/project/requests/2.28.1/"
+        )
+
+    def test_add_pypi_inspector_url_escapes_package_and_version(self):
+        results = {"issues": 1, "package_version": "1.0.0+local"}
+        guarddog.cli._add_pypi_inspector_url(results, "my package", ECOSYSTEM.PYPI)
+        assert (
+            results["pypi_inspector_url"]
+            == "https://inspector.pypi.io/project/my%20package/1.0.0%2Blocal/"
+        )
+
+    def test_add_pypi_inspector_url_skips_non_matching_scans(self):
+        results = {"issues": 0, "package_version": "2.28.1"}
+        guarddog.cli._add_pypi_inspector_url(results, "requests", ECOSYSTEM.PYPI)
+        assert "pypi_inspector_url" not in results
+
+        results = {"issues": 1, "package_version": "1.0.0"}
+        guarddog.cli._add_pypi_inspector_url(results, "lodash", ECOSYSTEM.NPM)
+        assert "pypi_inspector_url" not in results
+
     def _test_local_directory_template(self, directory: str):
         # `directory` is a directory
         with mock.patch("os.path.isdir") as isdir:

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -52,31 +52,6 @@ class TestCli(unittest.TestCase):
         rules = guarddog.cli._get_rule_param((), (), ECOSYSTEM.PYPI)
         assert rules is None
 
-    def test_add_pypi_inspector_url_for_pypi_scan_with_findings(self):
-        results = {"issues": 1, "package_version": "2.28.1"}
-        guarddog.cli._add_pypi_inspector_url(results, "requests", ECOSYSTEM.PYPI)
-        assert (
-            results["pypi_inspector_url"]
-            == "https://inspector.pypi.io/project/requests/2.28.1/"
-        )
-
-    def test_add_pypi_inspector_url_escapes_package_and_version(self):
-        results = {"issues": 1, "package_version": "1.0.0+local"}
-        guarddog.cli._add_pypi_inspector_url(results, "my package", ECOSYSTEM.PYPI)
-        assert (
-            results["pypi_inspector_url"]
-            == "https://inspector.pypi.io/project/my%20package/1.0.0%2Blocal/"
-        )
-
-    def test_add_pypi_inspector_url_skips_non_matching_scans(self):
-        results = {"issues": 0, "package_version": "2.28.1"}
-        guarddog.cli._add_pypi_inspector_url(results, "requests", ECOSYSTEM.PYPI)
-        assert "pypi_inspector_url" not in results
-
-        results = {"issues": 1, "package_version": "1.0.0"}
-        guarddog.cli._add_pypi_inspector_url(results, "lodash", ECOSYSTEM.NPM)
-        assert "pypi_inspector_url" not in results
-
     def _test_local_directory_template(self, directory: str):
         # `directory` is a directory
         with mock.patch("os.path.isdir") as isdir:

--- a/tests/core/test_pypi_package_scanner.py
+++ b/tests/core/test_pypi_package_scanner.py
@@ -51,3 +51,42 @@ def test_get_package_dist_path_none_when_no_supported_archive():
 def test_get_package_dist_path_none_for_unknown_version():
     scanner = PypiPackageScanner()
     assert scanner.get_package_dist_path(_package_info(), "9.9") is None
+
+
+def test_get_package_inspector_url_builds_project_url():
+    scanner = PypiPackageScanner()
+    url = scanner.get_package_inspector_url("requests", "2.28.1")
+    assert url == "https://inspector.pypi.io/project/requests/2.28.1/"
+
+
+def test_get_package_inspector_url_escapes_name_and_version():
+    scanner = PypiPackageScanner()
+    url = scanner.get_package_inspector_url("my package", "1.0.0+local")
+    assert url == "https://inspector.pypi.io/project/my%20package/1.0.0%2Blocal/"
+
+
+def test_annotate_remote_results_sets_links_when_findings_exist():
+    scanner = PypiPackageScanner()
+    results = {"issues": 1}
+    scanner._annotate_remote_results(
+        results, _package_info(), "aws-dd-forwarder", "1.0"
+    )
+    assert results["package_version"] == "1.0"
+    assert results["pypi_inspector_url"] == (
+        "https://inspector.pypi.io/project/aws-dd-forwarder/1.0/"
+    )
+    assert results["pypi_dist_path"] == (
+        "/packages/ab/cd/ef01/aws-dd-forwarder-1.0-py3-none-any.whl"
+    )
+
+
+def test_annotate_remote_results_omits_inspector_url_without_findings():
+    scanner = PypiPackageScanner()
+    results = {"issues": 0}
+    scanner._annotate_remote_results(
+        results, _package_info(), "aws-dd-forwarder", "1.0"
+    )
+    assert "pypi_inspector_url" not in results
+    # Version and distribution path are still recorded.
+    assert results["package_version"] == "1.0"
+    assert "pypi_dist_path" in results

--- a/tests/core/test_pypi_package_scanner.py
+++ b/tests/core/test_pypi_package_scanner.py
@@ -1,0 +1,53 @@
+from guarddog.scanners import PypiPackageScanner
+
+
+def _package_info():
+    return {
+        "info": {"version": "1.0"},
+        "releases": {
+            "1.0": [
+                {
+                    "filename": "aws-dd-forwarder-1.0-py3-none-any.whl",
+                    "url": (
+                        "https://files.pythonhosted.org/packages/ab/cd/"
+                        "ef01/aws-dd-forwarder-1.0-py3-none-any.whl"
+                    ),
+                },
+                {
+                    "filename": "aws-dd-forwarder-1.0.tar.gz",
+                    "url": (
+                        "https://files.pythonhosted.org/packages/f8/57/"
+                        "87be/aws-dd-forwarder-1.0.tar.gz"
+                    ),
+                },
+            ]
+        },
+    }
+
+
+def test_get_package_dist_path_returns_first_supported_archive_path():
+    scanner = PypiPackageScanner()
+    path = scanner.get_package_dist_path(_package_info(), "1.0")
+    assert path == "/packages/ab/cd/ef01/aws-dd-forwarder-1.0-py3-none-any.whl"
+
+
+def test_get_package_dist_path_defaults_to_latest_version():
+    scanner = PypiPackageScanner()
+    path = scanner.get_package_dist_path(_package_info())
+    assert path == "/packages/ab/cd/ef01/aws-dd-forwarder-1.0-py3-none-any.whl"
+
+
+def test_get_package_dist_path_none_when_no_supported_archive():
+    scanner = PypiPackageScanner()
+    package_info = {
+        "info": {"version": "1.0"},
+        "releases": {
+            "1.0": [{"filename": "aws-dd-forwarder-1.0.metadata", "url": "https://x/y"}]
+        },
+    }
+    assert scanner.get_package_dist_path(package_info, "1.0") is None
+
+
+def test_get_package_dist_path_none_for_unknown_version():
+    scanner = PypiPackageScanner()
+    assert scanner.get_package_dist_path(_package_info(), "9.9") is None

--- a/tests/reporters/test_human_readable.py
+++ b/tests/reporters/test_human_readable.py
@@ -60,7 +60,9 @@ def test_print_scan_results_escapes_malicious_filename_in_location():
         "issues": 1,
         "errors": {},
         "results": {},
-        "risks": [_risk(threat_location="evil\x1b[2J.py:3", file_path="evil\x1b[2J.py")],
+        "risks": [
+            _risk(threat_location="evil\x1b[2J.py:3", file_path="evil\x1b[2J.py")
+        ],
     }
     out = HumanReadableReporter.print_scan_results("pkg", results)
     assert not _has_raw_escape(out)
@@ -165,10 +167,38 @@ def test_print_scan_results_benign_input_is_preserved():
     assert "rule-name" in plain
 
 
+def test_print_scan_results_shows_pypi_inspector_url_for_matching_remote_scan():
+    results = {
+        "issues": 1,
+        "errors": {},
+        "results": {},
+        "risks": [_risk()],
+        "pypi_inspector_url": "https://inspector.pypi.io/project/requests/2.28.1/",
+    }
+    out = HumanReadableReporter.print_scan_results("requests", results)
+    plain = _strip_color(out)
+    assert "Package files:" in plain
+    assert "https://inspector.pypi.io/project/requests/2.28.1/" in plain
+
+
+def test_print_scan_results_hides_pypi_inspector_url_without_matches():
+    results = {
+        "issues": 0,
+        "errors": {},
+        "results": {},
+        "risks": [],
+        "pypi_inspector_url": "https://inspector.pypi.io/project/requests/2.28.1/",
+    }
+    out = HumanReadableReporter.print_scan_results("requests", results)
+    assert "inspector.pypi.io" not in _strip_color(out)
+
+
 def test_strip_prefix():
     strip = HumanReadableReporter._strip_prefix
     # Strips a common ancestor; leaves non-descendants and edge cases untouched.
-    assert strip("package/dist/node/axios.cjs:42", "package/dist") == "node/axios.cjs:42"
+    assert (
+        strip("package/dist/node/axios.cjs:42", "package/dist") == "node/axios.cjs:42"
+    )
     assert strip("package/dist/axios.js:7", "package/dist/") == "axios.js:7"
     assert strip("other/file.js:1", "package/dist") == "other/file.js:1"
     assert strip("package/dist", "package/dist") == "package/dist"
@@ -180,4 +210,7 @@ def test_strip_prefix():
         raise PermissionError(1, "Operation not permitted")
 
     with mock.patch("os.getcwd", blocked):
-        assert strip("package/dist/node/axios.cjs:42", "package/dist") == "node/axios.cjs:42"
+        assert (
+            strip("package/dist/node/axios.cjs:42", "package/dist")
+            == "node/axios.cjs:42"
+        )

--- a/tests/reporters/test_human_readable.py
+++ b/tests/reporters/test_human_readable.py
@@ -12,6 +12,15 @@ def _strip_color(text: str) -> str:
     return _ANSI_SEQ_RE.sub("", text)
 
 
+# OSC 8 hyperlink open (`\x1b]8;;URL\x1b\\`) and close (`\x1b]8;;\x1b\\`) wrappers.
+_OSC8_RE = re.compile(r"\x1b\]8;;[^\x1b\x07]*(?:\x1b\\|\x07)")
+
+
+def _visible_text(text: str) -> str:
+    """Strip OSC 8 hyperlink wrappers and SGR colors, leaving what a user reads."""
+    return _strip_color(_OSC8_RE.sub("", text))
+
+
 def _has_raw_escape(text: str, *, allow_color: bool = True) -> bool:
     """True if `text` still contains a raw ESC byte after optionally removing
     termcolor's own SGR sequences. The reporter is allowed to emit color codes
@@ -168,17 +177,21 @@ def test_print_scan_results_benign_input_is_preserved():
 
 
 def test_print_scan_results_shows_pypi_inspector_url_for_matching_remote_scan():
+    project_url = "https://inspector.pypi.io/project/requests/2.28.1/"
     results = {
         "issues": 1,
         "errors": {},
         "results": {},
         "risks": [_risk()],
-        "pypi_inspector_url": "https://inspector.pypi.io/project/requests/2.28.1/",
+        "pypi_inspector_url": project_url,
     }
     out = HumanReadableReporter.print_scan_results("requests", results)
-    plain = _strip_color(out)
-    assert "Package files:" in plain
-    assert "https://inspector.pypi.io/project/requests/2.28.1/" in plain
+    # The URL is the hyperlink target (present in the raw stream) but the visible
+    # text is a short label, not the full URL.
+    assert f"\x1b]8;;{project_url}\x1b\\" in out
+    visible = _visible_text(out)
+    assert "Package files: view on PyPI Inspector" in visible
+    assert project_url not in visible
 
 
 def test_print_scan_results_hides_pypi_inspector_url_without_matches():
@@ -191,6 +204,71 @@ def test_print_scan_results_hides_pypi_inspector_url_without_matches():
     }
     out = HumanReadableReporter.print_scan_results("requests", results)
     assert "inspector.pypi.io" not in _strip_color(out)
+
+
+def test_print_scan_results_shows_per_finding_inspector_deep_link():
+    results = {
+        "issues": 1,
+        "errors": {},
+        "results": {},
+        "risks": [
+            _risk(
+                threat_location="aws-dd-forwarder-1.0/lambda_function.py:31",
+                file_path="aws-dd-forwarder-1.0/lambda_function.py",
+            )
+        ],
+        "pypi_inspector_url": "https://inspector.pypi.io/project/aws-dd-forwarder/1.0/",
+        "pypi_dist_path": "/packages/f8/57/87be/aws-dd-forwarder-1.0.tar.gz",
+    }
+    out = HumanReadableReporter.print_scan_results("aws-dd-forwarder", results)
+    deep_url = (
+        "https://inspector.pypi.io/project/aws-dd-forwarder/1.0/packages/f8/57/87be/"
+        "aws-dd-forwarder-1.0.tar.gz/aws-dd-forwarder-1.0/lambda_function.py#line.31"
+    )
+    # The deep link is the finding location's hyperlink target; the visible text
+    # stays the location, not the raw URL.
+    assert f"\x1b]8;;{deep_url}\x1b\\" in out
+    visible = _visible_text(out)
+    assert "at aws-dd-forwarder-1.0/lambda_function.py:31" in visible
+    assert deep_url not in visible
+    # The project-level link is still shown alongside the deep links.
+    assert "Package files:" in visible
+
+
+def test_print_scan_results_no_deep_link_without_dist_path():
+    results = {
+        "issues": 1,
+        "errors": {},
+        "results": {},
+        "risks": [_risk(threat_location="pkg/mod.py:3", file_path="pkg/mod.py")],
+        "pypi_inspector_url": "https://inspector.pypi.io/project/pkg/1.0/",
+    }
+    out = HumanReadableReporter.print_scan_results("pkg", results)
+    assert "#line." not in _strip_color(out)
+
+
+def test_pypi_finding_inspector_url_encodes_path_and_requires_line():
+    base = "https://inspector.pypi.io/project/pkg/1.0/packages/aa/bb/cc/pkg-1.0.tar.gz"
+    url = HumanReadableReporter._pypi_finding_inspector_url(
+        base, "pkg-1.0/sub dir/mod.py:12"
+    )
+    assert url == base + "/pkg-1.0/sub%20dir/mod.py#line.12"
+
+    # Metadata findings have no line and get no deep link.
+    assert HumanReadableReporter._pypi_finding_inspector_url(base, "") is None
+    assert HumanReadableReporter._pypi_finding_inspector_url(base, "mod.py") is None
+
+
+def test_hyperlink_wraps_label_in_osc8_sequence():
+    link = HumanReadableReporter._hyperlink("https://example.com/x", "click me")
+    assert link == "\x1b]8;;https://example.com/x\x1b\\click me\x1b]8;;\x1b\\"
+
+
+def test_hyperlink_falls_back_to_plain_label_on_unsafe_url():
+    # A URL carrying an ESC or BEL could terminate the escape sequence early, so
+    # such urls are refused and only the bare label is returned.
+    assert HumanReadableReporter._hyperlink("https://x/\x1b\\evil", "label") == "label"
+    assert HumanReadableReporter._hyperlink("https://x/\x07evil", "label") == "label"
 
 
 def test_strip_prefix():


### PR DESCRIPTION
## Summary
- add resolved package version metadata to remote scan results
- generate a PyPI Inspector URL for remote PyPI scans with findings
- show the link in human-readable output to make package-file triage easier

Fixes #67

## Tests
- `.venv/bin/python -m pytest tests/reporters/test_human_readable.py tests/core/test_cli.py`
- `.venv/bin/python -m black --check guarddog/cli.py guarddog/reporters/human_readable.py guarddog/scanners/scanner.py guarddog/scanners/pypi_package_scanner.py tests/reporters/test_human_readable.py tests/core/test_cli.py`
- `git diff --check`