### PR TITLE
fix: false positive in fromCharCode obfuscation heuristic (#793)

### DIFF
--- a/guarddog/analyzer/sourcecode/threat-runtime-obfuscation-general.yar
+++ b/guarddog/analyzer/sourcecode/threat-runtime-obfuscation-general.yar
@@ -22,8 +22,11 @@ rule threat_runtime_obfuscation_general
         $js_jsfuck = /\[\s*!\s*!\s*\[\s*\]\s*\]/ nocase
         // JavaScript - packer pattern
         $js_packer = /\beval\s*\(\s*\bfunction\s*\([a-z],\s*[a-z],\s*[a-z],\s*[a-z]/ nocase
-        // JavaScript - very long fromCharCode (40+ chars indicates obfuscation, not unicode)
-        $js_fromcharcode = /\bString\s*\.\s*fromCharCode\s*\([^)]{40,}\)/ nocase
+        // JavaScript - fromCharCode over a long list of numeric literals (10+
+        // char codes indicates obfuscation). Requiring numeric arguments avoids
+        // false positives on legitimate long expressions such as
+        // String.fromCharCode(...someCall(args)) spread over multiple lines.
+        $js_fromcharcode = /\bString\s*\.\s*fromCharCode\s*\(\s*(0x[0-9a-fA-F]+|[0-9]+)(\s*,\s*(0x[0-9a-fA-F]+|[0-9]+)){9,}/ nocase
 
     condition:
         any of them

--- a/tests/analyzer/sourcecode/benign/threat-runtime-obfuscation-general.js
+++ b/tests/analyzer/sourcecode/benign/threat-runtime-obfuscation-general.js
@@ -1,0 +1,26 @@
+// Legitimate JavaScript that should NOT trigger threat-runtime-obfuscation-general
+
+// Decoding bytes returned by an API into a string, spread over multiple lines.
+// The fromCharCode argument is long but is a readable expression, not a list
+// of numeric char codes (reported as a false positive in issue #793).
+const checks = {
+  "key starts with expected prefix": (msgs) =>
+    String.fromCharCode(
+      ...registry.deserialize({
+        data: msgs[0].key,
+        schemaType: SCHEMA_TYPE_BYTES,
+      }),
+    ).startsWith("test-id-"),
+};
+
+// Converting a typed array to a string, a common decoding idiom.
+function bytesToString(bytes) {
+  return String.fromCharCode.apply(null, new Uint8Array(bytes));
+}
+
+// Spread of a computed array with a long variable name.
+const decoded = String.fromCharCode(...utf16CodeUnitsFromNetworkResponseBuffer);
+
+// Legitimate unicode usage with a handful of explicit char codes.
+const emoji = String.fromCharCode(0xd83d, 0xde00);
+const arrows = String.fromCharCode(8592, 8593, 8594, 8595);

--- a/tests/analyzer/sourcecode/threat-runtime-obfuscation-general.js
+++ b/tests/analyzer/sourcecode/threat-runtime-obfuscation-general.js
@@ -1,0 +1,11 @@
+// Obfuscated JavaScript patterns that MUST trigger threat-runtime-obfuscation-general
+
+// String built from a long list of numeric char codes (decimal)
+var cmd = String.fromCharCode(99, 117, 114, 108, 32, 104, 116, 116, 112, 58, 47, 47, 101, 118, 105, 108);
+
+// Same technique with hex literals, spread across lines
+var payload = String.fromCharCode(
+  0x63, 0x75, 0x72, 0x6c,
+  0x20, 0x68, 0x74, 0x74,
+  0x70, 0x3a, 0x2f, 0x2f
+);


### PR DESCRIPTION
Fixes #793.

**Problem.** The `$js_fromcharcode` string in `threat-runtime-obfuscation-general` matches any `String.fromCharCode` call whose argument text is 40+ characters. That includes readable, legitimate expressions spread over multiple lines, like the spread call in xk6-kafka's `test_bytes.js` that the issue reports: `String.fromCharCode(...schemaRegistry.deserialize({...}))`.

**Fix.** Real fromCharCode obfuscation encodes strings as long lists of numeric char codes. The pattern now requires 10+ comma-separated integer literals (decimal or hex) instead of arbitrary long argument text.

**Testing.**
- Reproduced the false positive on `xk6-kafka@v1.3.0/scripts/test_bytes.js` with the current rule; the fixed rule no longer matches it.
- New benign fixture covers the reported pattern plus other legitimate idioms (`fromCharCode.apply(null, bytes)`, spread of a computed array, short unicode lists).
- New malicious fixture locks in detection of decimal and hex char-code lists.
- Full YARA suite: 133 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)