### PR TITLE
fix(pypi): check both author and maintainer email in get_email_addresses

### DIFF
--- a/guarddog/analyzer/metadata/pypi/utils.py
+++ b/guarddog/analyzer/metadata/pypi/utils.py
@@ -1,4 +1,4 @@
 def get_email_addresses(package_info: dict) -> set[str]:
     info = package_info.get("info", {})
 
-    return {info.get("author_email") or info.get("maintainer_email")} - {None}
+    return {info.get("author_email"), info.get("maintainer_email")} - {None, ""}

--- a/tests/analyzer/metadata/test_pypi_utils.py
+++ b/tests/analyzer/metadata/test_pypi_utils.py
@@ -1,0 +1,17 @@
+from guarddog.analyzer.metadata.pypi.utils import get_email_addresses
+
+
+def test_get_email_addresses_returns_both_author_and_maintainer():
+    package_info = {
+        "info": {
+            "author_email": "realdev@example.com",
+            "maintainer_email": "maintainer@example.org",
+        }
+    }
+    emails = get_email_addresses(package_info)
+    assert emails == {"realdev@example.com", "maintainer@example.org"}
+
+
+def test_get_email_addresses_drops_none_and_empty():
+    package_info = {"info": {"author_email": "realdev@example.com", "maintainer_email": ""}}
+    assert get_email_addresses(package_info) == {"realdev@example.com"}


### PR DESCRIPTION
While reading the PyPI metadata detectors I noticed `get_email_addresses` only ever returns one address:

```python
return {info.get("author_email") or info.get("maintainer_email")} - {None}
```

The `or` short-circuits, so when `author_email` is set the maintainer email is never included. All three detectors that call it (`unclaimed_maintainer_email_domain`, `potentially_compromised_email_domain`, `deceptive_author`) then skip the maintainer address entirely whenever an author address is present. So a package whose `maintainer_email` domain is expired/unregistered (hijackable) is reported clean as long as it also has a normal `author_email`, which defeats the point of a detector literally named for the maintainer email.

The npm side already returns the full set (`{...}` comprehension over all emails), so this looks like an oversight rather than intent.

This returns both addresses and drops empty strings alongside `None`:

```python
return {info.get("author_email"), info.get("maintainer_email")} - {None, ""}
```

Added `tests/analyzer/metadata/test_pypi_utils.py`. I verified against the current code that the old form drops the maintainer email and the new form returns both (and still drops `None`/empty). I could not run the full suite locally since my machine is on Python 3.9 and the project targets 3.10+, so please let CI confirm.

Thanks for taking a look.