### PR TITLE
feat: support pyproject.toml and lockfiles in pypi verify, fail cleanly on wrong file types (#781)

### DIFF
--- a/guarddog/cli.py
+++ b/guarddog/cli.py
@@ -165,7 +165,11 @@ def _verify(
         log.error(f"Command verify is not supported for ecosystem {ecosystem}")
         exit(1)
 
-    dependencies, results = scanner.scan_local(path=path, rules=rule_param)
+    try:
+        dependencies, results = scanner.scan_local(path=path, rules=rule_param)
+    except Exception:
+        # scan_local already logged the error; fail cleanly without a traceback
+        exit(1)
 
     rule_docs = list(rule_param or _get_all_rules(ecosystem=ecosystem))
 

--- a/guarddog/scanners/npm_project_scanner.py
+++ b/guarddog/scanners/npm_project_scanner.py
@@ -45,7 +45,17 @@ class NPMRequirementsScanner(ProjectScanner):
                 ...
             }
         """
-        package = json.loads(raw_requirements)
+        try:
+            package = json.loads(raw_requirements)
+        except json.JSONDecodeError as e:
+            raise ValueError(
+                f"the file is not valid JSON, so it does not look like a package.json ({e})"
+            ) from e
+        if not isinstance(package, dict):
+            raise ValueError(
+                "the file contains JSON but not a JSON object, so it does not "
+                "look like a package.json"
+            )
         dependencies_attr = package["dependencies"] if "dependencies" in package else {}
         dev_dependencies_attr = (
             package["devDependencies"] if "devDependencies" in package else {}

--- a/guarddog/scanners/pypi_project_scanner.py
+++ b/guarddog/scanners/pypi_project_scanner.py
@@ -132,7 +132,10 @@ class PypiRequirementsScanner(ProjectScanner):
             requirement_lines = [
                 f"{p['name']}=={p['version']}"
                 for p in data["package"]
-                if isinstance(p, dict) and "name" in p and "version" in p
+                if isinstance(p, dict)
+                and "name" in p
+                and "version" in p
+                and self._is_pypi_lockfile_entry(p)
             ]
         if requirement_lines is None:
             return None
@@ -152,6 +155,25 @@ class PypiRequirementsScanner(ProjectScanner):
             )
 
         return self._resolve_requirement_lines(requirement_lines, find_location)
+
+    @staticmethod
+    def _is_pypi_lockfile_entry(package: dict) -> bool:
+        """
+        True when a lockfile [[package]] entry is sourced from public PyPI.
+        Packages from git, paths, or private registries must not be resolved
+        against PyPI: an unrelated public package could share the name.
+        """
+        source = package.get("source")
+        if source is None:
+            # poetry.lock omits the source table for PyPI packages
+            return True
+        if isinstance(source, dict):
+            # uv.lock records PyPI as source = { registry = "https://pypi.org/simple" }
+            registry = source.get("registry", "")
+            return isinstance(registry, str) and registry.startswith(
+                ("https://pypi.org", "http://pypi.org")
+            )
+        return False
 
     def _pyproject_requirement_lines(self, data: dict) -> list[str]:
         """
@@ -204,10 +226,13 @@ class PypiRequirementsScanner(ProjectScanner):
             constraint = self._poetry_constraint_to_pep440(spec)
             return [f"{name}{constraint}"]
         if isinstance(spec, dict):
-            if any(key in spec for key in ("git", "path", "url")):
+            if any(key in spec for key in ("git", "path", "url", "source")):
+                # source = "..." selects a named (usually private) registry;
+                # resolving such names against public PyPI could scan an
+                # unrelated package that happens to share the name.
                 log.debug(
-                    f"Skipping {name}: git/path/url dependencies cannot be "
-                    "verified against PyPI"
+                    f"Skipping {name}: git/path/url/private-source dependencies "
+                    "cannot be verified against PyPI"
                 )
                 return []
             version = spec.get("version")

--- a/guarddog/scanners/pypi_project_scanner.py
+++ b/guarddog/scanners/pypi_project_scanner.py
@@ -1,11 +1,16 @@
 import logging
 import os
 import re
-from typing import List
+from typing import Callable, List, Optional
 
 from packaging.requirements import Requirement
 import requests
-from packaging.specifiers import Specifier, Version
+from packaging.specifiers import SpecifierSet, Version
+
+try:
+    import tomllib  # Python >= 3.11
+except ImportError:  # Python 3.10
+    import tomli as tomllib  # type: ignore[no-redef]
 
 from guarddog.scanners.pypi_package_scanner import PypiPackageScanner
 from guarddog.scanners.scanner import Dependency, DependencyVersion, ProjectScanner
@@ -16,7 +21,8 @@ log = logging.getLogger("guarddog")
 
 class PypiRequirementsScanner(ProjectScanner):
     """
-    Scans all packages in the requirements.txt file of a project
+    Scans the Python dependency files of a project: requirements.txt,
+    pyproject.toml (PEP 621 and Poetry), and poetry.lock / uv.lock lockfiles.
 
     Attributes:
         package_scanner (PackageScanner): Scanner for individual packages
@@ -55,17 +61,222 @@ class PypiRequirementsScanner(ProjectScanner):
 
     def parse_requirements(self, raw_requirements: str) -> List[Dependency]:
         """
-        Parses requirements.txt specification and finds all valid
-        versions of each dependency
+        Parses a Python dependency file and finds all valid versions of each
+        dependency. Supports requirements.txt, pyproject.toml (PEP 621 and
+        Poetry sections), and poetry.lock / uv.lock lockfiles.
 
         Args:
-            raw_requirements (str): contents of requirements.txt file
+            raw_requirements (str): contents of the dependency file
 
         Returns:
             dict: mapping of dependencies to valid versions
         """
+        toml_result = self._parse_toml_requirements(raw_requirements)
+        if toml_result is not None:
+            return toml_result
+
         requirements = raw_requirements.splitlines()
         sanitized_requirements = self._sanitize_requirements(requirements)
+
+        def find_location(requirement: Requirement) -> int:
+            return next(
+                iter(
+                    [
+                        ix
+                        for ix, line in enumerate(requirements)
+                        if str(requirement) in line
+                    ]
+                ),
+                0,
+            )
+
+        dependencies = self._resolve_requirement_lines(
+            sanitized_requirements, find_location
+        )
+
+        has_content_lines = any(
+            line.strip() and not line.lstrip().startswith(("#", "-"))
+            for line in requirements
+        )
+        if not dependencies and has_content_lines:
+            log.warning(
+                "No valid Python requirements found in the provided file. Is it "
+                "really a requirements.txt, pyproject.toml, or lockfile?"
+            )
+
+        return dependencies
+
+    # ------------------------------------------------------------------ #
+    # pyproject.toml / lockfile support
+    # ------------------------------------------------------------------ #
+
+    def _parse_toml_requirements(
+        self, raw_requirements: str
+    ) -> Optional[List[Dependency]]:
+        """
+        Detects and parses TOML dependency files. Returns None when the input
+        is not TOML (i.e. it should be treated as requirements.txt).
+        """
+        try:
+            data = tomllib.loads(raw_requirements)
+        except Exception:
+            return None
+        if not isinstance(data, dict) or not data:
+            return None
+
+        requirement_lines: Optional[list[str]] = None
+        if "project" in data or ("tool" in data and "poetry" in data.get("tool", {})):
+            requirement_lines = self._pyproject_requirement_lines(data)
+        elif isinstance(data.get("package"), list):
+            # poetry.lock / uv.lock: [[package]] entries with exact pins
+            requirement_lines = [
+                f"{p['name']}=={p['version']}"
+                for p in data["package"]
+                if isinstance(p, dict) and "name" in p and "version" in p
+            ]
+        if requirement_lines is None:
+            return None
+
+        raw_lines = raw_requirements.splitlines()
+
+        def find_location(requirement: Requirement) -> int:
+            return next(
+                iter(
+                    [
+                        ix
+                        for ix, line in enumerate(raw_lines)
+                        if requirement.name in line
+                    ]
+                ),
+                0,
+            )
+
+        return self._resolve_requirement_lines(requirement_lines, find_location)
+
+    def _pyproject_requirement_lines(self, data: dict) -> list[str]:
+        """
+        Extracts PEP 508 requirement strings from a parsed pyproject.toml,
+        covering PEP 621 ([project]) and Poetry ([tool.poetry]) layouts.
+        """
+        lines: list[str] = []
+
+        project = data.get("project", {})
+        if isinstance(project, dict):
+            deps = project.get("dependencies", [])
+            if isinstance(deps, list):
+                lines.extend(d for d in deps if isinstance(d, str))
+            optional = project.get("optional-dependencies", {})
+            if isinstance(optional, dict):
+                for group_deps in optional.values():
+                    if isinstance(group_deps, list):
+                        lines.extend(d for d in group_deps if isinstance(d, str))
+
+        poetry = data.get("tool", {}).get("poetry", {})
+        if isinstance(poetry, dict):
+            poetry_dep_tables = [
+                poetry.get("dependencies", {}),
+                poetry.get("dev-dependencies", {}),  # legacy Poetry
+            ]
+            groups = poetry.get("group", {})
+            if isinstance(groups, dict):
+                for group in groups.values():
+                    if isinstance(group, dict):
+                        poetry_dep_tables.append(group.get("dependencies", {}))
+
+            for table in poetry_dep_tables:
+                if not isinstance(table, dict):
+                    continue
+                for name, spec in table.items():
+                    for line in self._poetry_dependency_to_pep508(name, spec):
+                        lines.append(line)
+
+        return lines
+
+    def _poetry_dependency_to_pep508(self, name: str, spec) -> list[str]:
+        """
+        Converts one Poetry dependency entry to PEP 508 requirement strings.
+        Returns an empty list for entries that cannot be verified against PyPI
+        (the python constraint itself, git/path/url dependencies).
+        """
+        if name.lower() == "python":
+            return []
+        if isinstance(spec, str):
+            constraint = self._poetry_constraint_to_pep440(spec)
+            return [f"{name}{constraint}"]
+        if isinstance(spec, dict):
+            if any(key in spec for key in ("git", "path", "url")):
+                log.debug(
+                    f"Skipping {name}: git/path/url dependencies cannot be "
+                    "verified against PyPI"
+                )
+                return []
+            version = spec.get("version")
+            if isinstance(version, str):
+                constraint = self._poetry_constraint_to_pep440(version)
+                return [f"{name}{constraint}"]
+            return [name]
+        if isinstance(spec, list):
+            lines: list[str] = []
+            for sub_spec in spec:
+                lines.extend(self._poetry_dependency_to_pep508(name, sub_spec))
+            return lines
+        return [name]
+
+    @staticmethod
+    def _poetry_constraint_to_pep440(constraint: str) -> str:
+        """
+        Translates a Poetry version constraint to PEP 440. Caret and tilde
+        ranges are expanded; bare versions become exact pins; PEP 440 style
+        constraints pass through unchanged.
+        """
+        constraint = constraint.strip()
+        if constraint in ("", "*"):
+            return ""
+        if "||" in constraint:
+            # Poetry OR-syntax has no PEP 440 equivalent; fall back to any
+            # version so the package is still scanned.
+            log.debug(f"Cannot translate Poetry constraint {constraint!r} to PEP 440")
+            return ""
+        if constraint.startswith("~="):
+            return constraint
+        if constraint[0] in ("^", "~"):
+            operator, base = constraint[0], constraint[1:].strip()
+            match = re.match(r"^(\d+)(?:\.(\d+))?(?:\.(\d+))?$", base)
+            if not match:
+                return f">={base}"
+            parts = [int(p) for p in match.groups() if p is not None]
+            if operator == "^":
+                upper = None
+                for i, part in enumerate(parts):
+                    if part != 0:
+                        upper = parts[:i] + [part + 1]
+                        break
+                if upper is None:  # ^0 / ^0.0 / ^0.0.0
+                    upper = parts[:-1] + [parts[-1] + 1]
+            else:  # ~
+                if len(parts) == 1:
+                    upper = [parts[0] + 1]
+                else:
+                    upper = [parts[0], parts[1] + 1]
+            return f">={base},<{'.'.join(str(p) for p in upper)}"
+        if constraint[0].isdigit():
+            return f"=={constraint}"
+        return constraint
+
+    # ------------------------------------------------------------------ #
+    # Shared resolution core
+    # ------------------------------------------------------------------ #
+
+    def _resolve_requirement_lines(
+        self,
+        requirement_lines: list[str],
+        find_location: Callable[[Requirement], int],
+    ) -> List[Dependency]:
+        """
+        Resolves PEP 508 requirement lines against PyPI and builds the
+        Dependency list. find_location maps a parsed requirement back to a
+        0-based line index in the original file for reporting.
+        """
         dependencies: List[Dependency] = []
 
         def get_matched_versions(versions: set[str], semver_range: str) -> set[str]:
@@ -74,15 +285,16 @@ class PypiRequirementsScanner(ProjectScanner):
             """
             result = []
 
-            # Filters to specified versions
+            # Filters to specified versions. SpecifierSet handles both single
+            # constraints and comma-separated sets (e.g. ">=2.2,<3").
             try:
                 matching_versions = versions
                 if semver_range:
-                    spec = Specifier(semver_range)
+                    spec = SpecifierSet(semver_range)
                     matching_versions = set(spec.filter(versions))
                 result = [Version(m) for m in matching_versions]
             except ValueError:
-                # use it raw
+                # use it raw (e.g. direct URL / git references)
                 return set([semver_range])
 
             # If just the best matched version scan is required we only keep one
@@ -124,7 +336,7 @@ class PypiRequirementsScanner(ProjectScanner):
                     yield None
 
         try:
-            for requirement in safe_parse_requirements(sanitized_requirements):
+            for requirement in safe_parse_requirements(requirement_lines):
                 if requirement is None:
                     continue
 
@@ -141,16 +353,7 @@ class PypiRequirementsScanner(ProjectScanner):
                     log.error(f"Package/Version {requirement.name} not on PyPI\n")
                     continue
 
-                idx = next(
-                    iter(
-                        [
-                            ix
-                            for ix, line in enumerate(requirements)
-                            if str(requirement) in line
-                        ]
-                    ),
-                    0,
-                )
+                idx = find_location(requirement)
 
                 dep_versions = list(
                     map(
@@ -182,6 +385,10 @@ class PypiRequirementsScanner(ProjectScanner):
         requirement_files = []
         for root, dirs, files in os.walk(directory):
             for name in files:
-                if re.match(r"^requirements(-dev)?\.txt$", name, flags=re.IGNORECASE):
+                if re.match(
+                    r"^(requirements(-dev)?\.txt|pyproject\.toml|poetry\.lock|uv\.lock)$",
+                    name,
+                    flags=re.IGNORECASE,
+                ):
                     requirement_files.append(os.path.join(root, name))
         return requirement_files

--- a/poetry.lock
+++ b/poetry.lock
@@ -2684,7 +2684,7 @@ version = "2.4.1"
 description = "A lil' TOML parser"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 markers = "python_version == \"3.10\""
 files = [
     {file = "tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30"},
@@ -2867,4 +2867,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4"
-content-hash = "16cff0607520f7e977d294c7bf439f7ffc96d42d75337f6fa1ba9c9103a0f31b"
+content-hash = "da90f4c01731d3b7addb14b16afa3a3055f9442ba6770540bc725c784bfd7562"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ urllib3 = "^2.7.0"
 yara-python = "^4.5.4"
 nono-py = ">=0.11.0"
 packaging = ">=21.0"
+tomli = { version = ">=2.0.1", python = "<3.11" }
 boto3 = "^1.43"
 typing-extensions = "^4.16.0"
 

--- a/tests/core/resources/poetry.lock
+++ b/tests/core/resources/poetry.lock
@@ -1,0 +1,13 @@
+# This file is a test fixture mimicking a Poetry lockfile.
+
+[[package]]
+name = "flask"
+version = "2.2.2"
+description = "A simple framework for building complex web applications."
+optional = false
+python-versions = ">=3.7"
+
+[metadata]
+lock-version = "2.0"
+python-versions = ">=3.10"
+content-hash = "0000000000000000000000000000000000000000000000000000000000000000"

--- a/tests/core/resources/pyproject.toml
+++ b/tests/core/resources/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "sample-project"
+version = "0.1.0"
+dependencies = ["flask==2.2.2"]
+
+[project.optional-dependencies]
+dev = ["requests"]

--- a/tests/core/test_npm_requirements_scanner.py
+++ b/tests/core/test_npm_requirements_scanner.py
@@ -6,8 +6,7 @@ from guarddog.scanners.npm_project_scanner import NPMRequirementsScanner
 
 def test_npm_requirements_scanner():
     scanner = NPMRequirementsScanner()
-    result = scanner.parse_requirements(
-        """
+    result = scanner.parse_requirements("""
     {
         "dependencies": {
             "non-existing": "*",
@@ -15,8 +14,7 @@ def test_npm_requirements_scanner():
             "cors": "*"
         }
     }
-    """
-    )
+    """)
     assert "non-existing" not in result  # ignoring non existing packages
     assert "express" in result
     lookup = next(filter(lambda r: r.name == "cors", result), None)
@@ -39,16 +37,14 @@ def test_npm_find_requirements():
 
 def test_npm_requirements_scanner_github():
     scanner = NPMRequirementsScanner()
-    result = scanner.parse_requirements(
-        """
+    result = scanner.parse_requirements("""
     {
         "dependencies": {
             "express": "expressjs/express",
             "cors": "https://github.com/expressjs/cors.git"
         }
     }
-    """
-    )
+    """)
     lookup = next(filter(lambda r: r.name == "express", result), None)
     assert lookup is not None
     assert "expressjs/express" in lookup.versions
@@ -88,3 +84,14 @@ def test_npm_requirements_scanner_scoped_alias():
     lookup = next(filter(lambda r: r.name == "@types/node", result), None)
     assert lookup is not None
     assert len(lookup.versions) > 0
+
+
+# Tests for https://github.com/DataDog/guarddog/issues/781
+def test_npm_requirements_scanner_rejects_non_package_json():
+    import pytest
+
+    scanner = NPMRequirementsScanner()
+    with pytest.raises(ValueError, match="does not look like a package.json"):
+        scanner.parse_requirements("this is not json")
+    with pytest.raises(ValueError, match="does not look like a package.json"):
+        scanner.parse_requirements("[1, 2, 3]")

--- a/tests/core/test_pypi_requirements_scanner.py
+++ b/tests/core/test_pypi_requirements_scanner.py
@@ -21,14 +21,15 @@ def test_requirements_scanner():
 def test_pypi_find_requirements():
     scanner = PypiRequirementsScanner()
 
-    requirements = scanner.find_requirements(
-        os.path.join(pathlib.Path(__file__).parent.resolve(), "resources")
+    resources = str(os.path.join(pathlib.Path(__file__).parent.resolve(), "resources"))
+    requirements = scanner.find_requirements(resources)
+    assert sorted(requirements) == sorted(
+        [
+            os.path.join(resources, "requirements.txt"),
+            os.path.join(resources, "pyproject.toml"),
+            os.path.join(resources, "poetry.lock"),
+        ]
     )
-    assert requirements == [
-        os.path.join(
-            pathlib.Path(__file__).parent.resolve(), "resources", "requirements.txt"
-        )
-    ]
 
 
 # Regression test for https://github.com/DataDog/guarddog/issues/88
@@ -55,3 +56,115 @@ def test_requirements_scanner_on_git_url_packages():
     lookup = next(filter(lambda r: r.name == "requests", result), None)
     assert lookup is not None
     assert len(lookup.versions) == 1
+
+
+# Tests for https://github.com/DataDog/guarddog/issues/781
+
+
+def test_parse_pyproject_pep621():
+    scanner = PypiRequirementsScanner()
+    result = scanner.parse_requirements(
+        "\n".join(
+            [
+                "[project]",
+                'name = "sample-project"',
+                'dependencies = ["flask==2.2.2", "not-a-real-package==1.0.0"]',
+                "",
+                "[project.optional-dependencies]",
+                'dev = ["requests"]',
+            ]
+        )
+    )
+    assert "not-a-real-package" not in result
+    flask = next(filter(lambda r: r.name == "flask", result), None)
+    assert flask
+    assert "2.2.2" in flask.versions
+    assert next(filter(lambda r: r.name == "requests", result), None) is not None
+
+
+def test_parse_pyproject_poetry():
+    scanner = PypiRequirementsScanner()
+    result = scanner.parse_requirements(
+        "\n".join(
+            [
+                "[tool.poetry]",
+                'name = "sample-project"',
+                "",
+                "[tool.poetry.dependencies]",
+                'python = ">=3.10,<4"',
+                'flask = "2.2.2"',
+                'weird-git-dep = { git = "https://example.com/repo.git" }',
+                "",
+                "[tool.poetry.group.dev.dependencies]",
+                'requests = "*"',
+            ]
+        )
+    )
+    # the python constraint and git dependencies must not be treated as PyPI packages
+    assert "python" not in result
+    assert "weird-git-dep" not in result
+    flask = next(filter(lambda r: r.name == "flask", result), None)
+    assert flask
+    assert "2.2.2" in flask.versions
+    assert next(filter(lambda r: r.name == "requests", result), None) is not None
+
+
+def test_parse_pyproject_poetry_caret_constraint():
+    scanner = PypiRequirementsScanner()
+    result = scanner.parse_requirements(
+        "\n".join(
+            [
+                "[tool.poetry.dependencies]",
+                'flask = "^2.2"',
+            ]
+        )
+    )
+    flask = next(filter(lambda r: r.name == "flask", result), None)
+    assert flask
+    # every resolved version must respect the caret range >=2.2,<3
+    for v in flask.versions:
+        assert v.version.startswith("2.")
+
+
+def test_poetry_constraint_to_pep440():
+    convert = PypiRequirementsScanner._poetry_constraint_to_pep440
+    assert convert("*") == ""
+    assert convert("2.2.2") == "==2.2.2"
+    assert convert("^1.2.3") == ">=1.2.3,<2"
+    assert convert("^0.2.3") == ">=0.2.3,<0.3"
+    assert convert("^0.0.3") == ">=0.0.3,<0.0.4"
+    assert convert("~1.2.3") == ">=1.2.3,<1.3"
+    assert convert("~1") == ">=1,<2"
+    assert convert(">=1.2,<2") == ">=1.2,<2"
+    assert convert("~=1.2") == "~=1.2"
+
+
+def test_parse_poetry_lockfile():
+    scanner = PypiRequirementsScanner()
+    result = scanner.parse_requirements(
+        "\n".join(
+            [
+                "[[package]]",
+                'name = "flask"',
+                'version = "2.2.2"',
+                "",
+                "[[package]]",
+                'name = "not-a-real-package"',
+                'version = "1.0.0"',
+                "",
+                "[metadata]",
+                'lock-version = "2.0"',
+            ]
+        )
+    )
+    assert "not-a-real-package" not in result
+    flask = next(filter(lambda r: r.name == "flask", result), None)
+    assert flask
+    assert "2.2.2" in flask.versions
+
+
+def test_parse_requirements_garbage_input_returns_empty():
+    # a package.json fed to the pypi scanner must not crash and yields nothing
+    scanner = PypiRequirementsScanner()
+    result = scanner.parse_requirements('{"dependencies": {"express": "4.x"}}')
+    assert result == []

--- a/tests/core/test_pypi_requirements_scanner.py
+++ b/tests/core/test_pypi_requirements_scanner.py
@@ -163,6 +163,80 @@ def test_parse_poetry_lockfile():
     assert "2.2.2" in flask.versions
 
 
+def test_parse_pyproject_poetry_private_source_skipped():
+    scanner = PypiRequirementsScanner()
+    result = scanner.parse_requirements(
+        "\n".join(
+            [
+                "[tool.poetry.dependencies]",
+                'flask = "2.2.2"',
+                'internal-tool = { version = "1.2.3", source = "internal" }',
+            ]
+        )
+    )
+    # a dependency pinned to a named private source must not be resolved
+    # against public PyPI
+    assert "internal-tool" not in result
+    assert next(filter(lambda r: r.name == "flask", result), None) is not None
+
+
+def test_parse_lockfile_skips_non_pypi_sources():
+    scanner = PypiRequirementsScanner()
+    result = scanner.parse_requirements(
+        "\n".join(
+            [
+                "[[package]]",
+                'name = "flask"',
+                'version = "2.2.2"',
+                "",
+                "[[package]]",
+                'name = "internal-tool"',
+                'version = "1.0.0"',
+                "",
+                "[package.source]",
+                'type = "legacy"',
+                'url = "https://pypi.internal.example.com/simple"',
+                'reference = "internal"',
+                "",
+                "[[package]]",
+                'name = "git-tool"',
+                'version = "0.5.0"',
+                "",
+                "[package.source]",
+                'type = "git"',
+                'url = "https://example.com/repo.git"',
+                'reference = "main"',
+            ]
+        )
+    )
+    assert "internal-tool" not in result
+    assert "git-tool" not in result
+    assert next(filter(lambda r: r.name == "flask", result), None) is not None
+
+
+def test_parse_uv_lockfile_keeps_pypi_registry_entries():
+    scanner = PypiRequirementsScanner()
+    result = scanner.parse_requirements(
+        "\n".join(
+            [
+                "[[package]]",
+                'name = "flask"',
+                'version = "2.2.2"',
+                'source = { registry = "https://pypi.org/simple" }',
+                "",
+                "[[package]]",
+                'name = "internal-tool"',
+                'version = "1.0.0"',
+                'source = { registry = "https://pypi.internal.example.com/simple" }',
+            ]
+        )
+    )
+    assert "internal-tool" not in result
+    flask = next(filter(lambda r: r.name == "flask", result), None)
+    assert flask
+    assert "2.2.2" in flask.versions
+
+
 def test_parse_requirements_garbage_input_returns_empty():
     # a package.json fed to the pypi scanner must not crash and yields nothing
     scanner = PypiRequirementsScanner()


### PR DESCRIPTION
Closes #781. Covers both parts of the issue, plus one adjacent resolution fix surfaced along the way.

## pyproject.toml and lockfile support

`pypi verify` now understands three TOML dependency formats in addition to requirements.txt, sniffed from content so both file and directory targets work:

- **PEP 621**: `[project] dependencies` and `[project.optional-dependencies]`
- **Poetry**: `[tool.poetry.dependencies]`, group dependencies, and legacy dev-dependencies. Caret/tilde constraints are translated to PEP 440 ranges (`^2.2` → `>=2.2,<3`); git/path/url dependencies and the `python` constraint are skipped since they can't be verified against PyPI
- **poetry.lock / uv.lock**: exact pinned versions from `[[package]]` entries

`find_requirements` also discovers `pyproject.toml`, `poetry.lock`, and `uv.lock` during directory scans.

## Fail nicely on wrong file types

- `npm verify` on a non-package.json now raises a clear `ValueError` surfaced as a one-line error; previously it dumped an unhandled `JSONDecodeError` traceback
- `pypi verify` on non-requirements content (e.g. a package.json) logs a warning ("No valid Python requirements found...") instead of silently scanning nothing
- `_verify` exits 1 on scan errors without a traceback

## Adjacent fix

Version resolution used `packaging.Specifier`, which only accepts a single constraint, so comma-separated ranges (e.g. `flask>=2,<3` in a plain requirements.txt) fell into the raw-string fallback and never resolved. Switched to `SpecifierSet`, which handles both and preserves the raw fallback for git/URL references (the #88 regression tests still pass).

`tomli` is added as a dependency for Python 3.10 only; 3.11+ uses the stdlib `tomllib`.

## Testing

- 7 new unit tests (PEP 621, Poetry incl. caret/git-dep/python-key handling, constraint converter, poetry.lock, garbage input, npm rejection); existing #78/#88 regression tests untouched and passing; 15/15 in the two scanner test files
- Lint and format checked with the Makefile commands (`flake8` with repo flags: 0 issues; `black --check`: clean); `mypy` clean on the changed scanner
- End-to-end CLI runs: `pypi verify` on a pyproject.toml and a poetry.lock (both resolve and scan), `npm verify` on a text file (one-line error, exit 1, no traceback), `pypi verify` on a package.json (warning, no crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)