### PR TITLE
fix: npm metadata checks for @types package roots

### DIFF
--- a/guarddog/analyzer/metadata/npm/metadata_mismatch.py
+++ b/guarddog/analyzer/metadata/npm/metadata_mismatch.py
@@ -14,6 +14,33 @@ MANIFEST_FIELDS_CHECKLIST = {
 }
 
 
+def _load_package_manifest(path: str, package_name: Optional[str]) -> Dict[str, Any]:
+    """Load package.json from a supported npm tarball root.
+
+    npm normally stores package contents under ``package/``. DefinitelyTyped
+    packages instead use the unscoped package name (for example,
+    ``@types/express`` extracts to ``express/``).
+    """
+    root = Path(path)
+    candidates = [root / "package" / "package.json"]
+    if package_name:
+        unscoped_name = package_name.rsplit("/", 1)[-1]
+        named_manifest = root / unscoped_name / "package.json"
+        if named_manifest not in candidates:
+            candidates.append(named_manifest)
+
+    for package_json in candidates:
+        try:
+            return json.loads(package_json.read_text())
+        except FileNotFoundError:
+            continue
+
+    expected_paths = ", ".join(str(candidate) for candidate in candidates)
+    raise FileNotFoundError(
+        f"package.json was not found at an expected npm archive root: {expected_paths}"
+    )
+
+
 class NPMMetadataMismatchDetector(MetadataMismatchDetector):
     """Compares npm registry metadata against the package.json inside the tarball.
 
@@ -35,8 +62,8 @@ class NPMMetadataMismatchDetector(MetadataMismatchDetector):
         # Load package.json manifest
         if path is None:
             raise ValueError("path is needed to run heuristic " + self.get_name())
-        package_json = Path(path) / "package" / "package.json"
-        package_manifest: Dict[str, Any] = json.loads(package_json.read_text())
+        package_name = name or package_info.get("name")
+        package_manifest = _load_package_manifest(path, package_name)
 
         # Get NPM manifest for version
         version_info = package_info["versions"][version]

--- a/tests/analyzer/metadata/test_npm_metadata_mismatch.py
+++ b/tests/analyzer/metadata/test_npm_metadata_mismatch.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+import json
 
 import pytest
 
@@ -86,9 +87,7 @@ class TestNPMMetadataMismatch:
         )
         assert result == modification[3]
 
-    def test_git_url_trailing_dot_git_no_false_positive(
-        self, mocker, npm_package_info
-    ):
+    def test_git_url_trailing_dot_git_no_false_positive(self, mocker, npm_package_info):
         """Git URLs differing only by trailing .git should not trigger a mismatch.
 
         Regression test for https://github.com/DataDog/guarddog/issues/634
@@ -110,6 +109,27 @@ class TestNPMMetadataMismatch:
 
         result, _ = self.mismatch_detector.detect(npm_version_metadata, path="./")
         assert result is False
+
+    def test_definitelytyped_package_root(self, tmp_path, npm_package_info):
+        """DefinitelyTyped tarballs use the unscoped name as their root."""
+        package_info = deepcopy(npm_package_info)
+        package_info["name"] = "@types/express"
+        package_info["versions"][self.target_version]["name"] = "@types/express"
+        package_manifest = deepcopy(package_info["versions"][self.target_version])
+
+        package_root = tmp_path / "express"
+        package_root.mkdir()
+        (package_root / "package.json").write_text(json.dumps(package_manifest))
+
+        result, description = self.mismatch_detector.detect(
+            package_info,
+            path=str(tmp_path),
+            name="@types/express",
+            version=self.target_version,
+        )
+
+        assert result is False
+        assert description == "No differences found"
 
 
 class TestNormalizeGitUrl:
@@ -140,7 +160,10 @@ class TestNormalizeGitUrl:
     def test_non_git_url_unchanged(self):
         assert _normalize_git_url("1.2.3") == "1.2.3"
         assert _normalize_git_url("^2.0.0") == "^2.0.0"
-        assert _normalize_git_url("https://example.com/pkg.git") == "https://example.com/pkg.git"
+        assert (
+            _normalize_git_url("https://example.com/pkg.git")
+            == "https://example.com/pkg.git"
+        )
 
     def test_none_passthrough(self):
         assert _normalize_git_url(None) is None


### PR DESCRIPTION
## Summary

- keep `package/package.json` as the primary npm archive manifest path
- fall back to `<unscoped-package-name>/package.json` for DefinitelyTyped tarballs such as `@types/express`
- avoid recursive manifest discovery so nested package manifests cannot be selected accidentally
- add regression coverage for the DefinitelyTyped archive layout

## Test plan

- `poetry run pytest tests/analyzer/metadata/test_npm_metadata_mismatch.py` (21 passed)
- `poetry run pytest tests/analyzer/metadata` (125 passed)
- `poetry run black --check guarddog/analyzer/metadata/npm/metadata_mismatch.py tests/analyzer/metadata/test_npm_metadata_mismatch.py`
- `poetry run flake8 guarddog/analyzer/metadata/npm/metadata_mismatch.py --max-line-length=120 --ignore=E203,W503`

Closes #832.