### PR TITLE
fix: run sandboxed archive scans from the temporary directory

### DIFF
--- a/guarddog/cli.py
+++ b/guarddog/cli.py
@@ -186,6 +186,15 @@ def _verify(
     return return_value  # this is mostly for testing
 
 
+def _apply_archive_sandbox(tempdir: str, tmp_root: str) -> None:
+    """Apply the sandbox from the temporary root used for archive work."""
+    # tarsafe reads the current directory during extraction. Move to the
+    # persistent temp root, which the sandbox already allows, before locking
+    # down the process.
+    os.chdir(tmp_root)
+    apply_sandbox(scan_paths=[], writable_paths=[tempdir])
+
+
 def _scan(
     identifier,
     version,
@@ -275,7 +284,7 @@ def _scan(
                 sandboxed_archive = os.path.join(tempdir, os.path.basename(identifier))
                 shutil.copyfile(identifier, sandboxed_archive)
                 if sandbox:
-                    apply_sandbox(scan_paths=[], writable_paths=[tempdir])
+                    _apply_archive_sandbox(tempdir, tmp_root)
                 extract_dir = os.path.join(tempdir, "_extracted")
                 os.makedirs(extract_dir, exist_ok=True)
                 safe_extract(
@@ -306,7 +315,7 @@ def _scan(
                 with open(archive_path, "wb") as f:
                     f.write(response.raw.read())
                 if sandbox:
-                    apply_sandbox(scan_paths=[], writable_paths=[tempdir])
+                    _apply_archive_sandbox(tempdir, tmp_root)
                 extract_dir = os.path.join(tempdir, "_extracted")
                 os.makedirs(extract_dir, exist_ok=True)
                 safe_extract(archive_path, extract_dir, zip_password=zip_password_bytes)
@@ -337,7 +346,10 @@ def _scan(
                 # http/https branch).
                 kind, local_path = download_from_s3(identifier, download_root)
                 if sandbox:
-                    apply_sandbox(scan_paths=[], writable_paths=[tempdir])
+                    if kind == "archive":
+                        _apply_archive_sandbox(tempdir, tmp_root)
+                    else:
+                        apply_sandbox(scan_paths=[], writable_paths=[tempdir])
                 if kind == "archive":
                     extract_dir = os.path.join(tempdir, "_extracted")
                     os.makedirs(extract_dir, exist_ok=True)

--- a/guarddog/sandbox.py
+++ b/guarddog/sandbox.py
@@ -139,13 +139,6 @@ def _get_common_read_paths() -> list[str]:
 
     candidates = [sys.prefix, sys.base_prefix, "/usr", "/lib"]
 
-    # Current working directory: sandboxed scanning runs from wherever the
-    # user's shell happens to be, and tarsafe calls os.getcwd() during
-    # extraction to bound path-traversal checks. Without READ access here
-    # that call fails with PermissionError, which tarfile misreports as
-    # "not a gzip file".
-    candidates.append(os.getcwd())
-
     # SSL certificate directories: pygit2 initializes OpenSSL at import time and
     # reads the system CA bundle. On Linux (Landlock), only explicitly listed paths
     # are readable — unlike macOS (Seatbelt) which includes system paths by default.

--- a/guarddog/sandbox.py
+++ b/guarddog/sandbox.py
@@ -139,6 +139,13 @@ def _get_common_read_paths() -> list[str]:
 
     candidates = [sys.prefix, sys.base_prefix, "/usr", "/lib"]
 
+    # Current working directory: sandboxed scanning runs from wherever the
+    # user's shell happens to be, and tarsafe calls os.getcwd() during
+    # extraction to bound path-traversal checks. Without READ access here
+    # that call fails with PermissionError, which tarfile misreports as
+    # "not a gzip file".
+    candidates.append(os.getcwd())
+
     # SSL certificate directories: pygit2 initializes OpenSSL at import time and
     # reads the system CA bundle. On Linux (Landlock), only explicitly listed paths
     # are readable — unlike macOS (Seatbelt) which includes system paths by default.

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -11,6 +11,31 @@ import guarddog.scanners.scanner as scanner
 
 class TestCli(unittest.TestCase):
 
+    def test_archive_sandbox_changes_to_temp_root_before_lockdown(self):
+        """Archive extraction starts from the allowed temporary root."""
+        order = []
+
+        with mock.patch(
+            "guarddog.cli.os.chdir",
+            side_effect=lambda path: order.append(("chdir", path)),
+        ):
+            with mock.patch(
+                "guarddog.cli.apply_sandbox",
+                side_effect=lambda **kwargs: order.append(("sandbox", kwargs)),
+            ):
+                guarddog.cli._apply_archive_sandbox("/tmp/guarddog-scan", "/tmp")
+
+        self.assertEqual(
+            order,
+            [
+                ("chdir", "/tmp"),
+                (
+                    "sandbox",
+                    {"scan_paths": [], "writable_paths": ["/tmp/guarddog-scan"]},
+                ),
+            ],
+        )
+
     def test_local_directory(self):
         """
         Test that the CLI identifies local directories correctly

--- a/tests/core/test_sandbox.py
+++ b/tests/core/test_sandbox.py
@@ -63,12 +63,12 @@ class TestApplySandbox:
         paths = _get_common_read_paths()
         assert any(p == os.path.realpath(sys.prefix) for p in paths)
 
-    def test_common_read_paths_includes_cwd(self):
-        """os.getcwd() must be readable: tarsafe calls it during extraction
-        to bound path-traversal checks, and the sandbox otherwise denies it
-        with a PermissionError that tarfile misreports as corrupt data."""
+    @patch("guarddog.sandbox.os.getcwd", side_effect=FileNotFoundError)
+    def test_common_read_paths_does_not_require_cwd(self, mock_getcwd):
+        """Building the common allowlist does not depend on the current directory."""
         paths = _get_common_read_paths()
-        assert os.path.realpath(os.getcwd()) in paths
+        assert paths
+        mock_getcwd.assert_not_called()
 
 
 class TestPathVariants:

--- a/tests/core/test_sandbox.py
+++ b/tests/core/test_sandbox.py
@@ -63,6 +63,13 @@ class TestApplySandbox:
         paths = _get_common_read_paths()
         assert any(p == os.path.realpath(sys.prefix) for p in paths)
 
+    def test_common_read_paths_includes_cwd(self):
+        """os.getcwd() must be readable: tarsafe calls it during extraction
+        to bound path-traversal checks, and the sandbox otherwise denies it
+        with a PermissionError that tarfile misreports as corrupt data."""
+        paths = _get_common_read_paths()
+        assert os.path.realpath(os.getcwd()) in paths
+
 
 class TestPathVariants:
     def test_plain_path_returns_single_entry(self):


### PR DESCRIPTION
## Summary

Fix local archive scans that fail under the kernel-level sandbox with a misleading "not a gzip file" error.

`tarsafe` reads the current directory during extraction. Archive scans now change into the persistent temporary root before the sandbox is applied. This keeps the caller's directory private while giving `tarsafe` a working directory that the sandbox already allows.

## Changes

- Run local, HTTP, and S3 archive extraction from the allowed temporary root.
- Stop adding the caller's current directory to the common sandbox read paths.
- Add coverage for sandbox ordering and for an unavailable current directory.

## Test plan

- `pytest`: 479 passed, 2 skipped.
- `pytest tests/core`: 191 passed, 2 skipped.
- `black --check guarddog scripts`
- `flake8 guarddog`
- `mypy guarddog`
- A real sandboxed scan of `tests/core/resources/archives/plain.tar.gz` from `/home/pasen` completed successfully.

Fixes #818