### PR TITLE
Run Yara rules in deterministic order to avoid non-deterministic scan output

### DIFF
--- a/guarddog/analyzer/analyzer.py
+++ b/guarddog/analyzer/analyzer.py
@@ -390,9 +390,9 @@ class Analyzer:
             all_rules = self.yara_ruleset & rules
 
         # Sort for deterministic result/rule ordering across machines (#828)
-        all_rules = sorted(all_rules)
+        sorted_rules = sorted(all_rules)
 
-        results = {rule: {} for rule in all_rules}  # type: dict
+        results = {rule: {} for rule in sorted_rules}  # type: dict
         errors: Dict[str, str] = {}
         issues = 0
 
@@ -400,7 +400,7 @@ class Analyzer:
 
         rules_path = {
             rule_name: os.path.join(SOURCECODE_RULES_PATH, f"{rule_name}.yar")
-            for rule_name in all_rules
+            for rule_name in sorted_rules
         }
 
         if len(rules_path) == 0:

--- a/guarddog/analyzer/analyzer.py
+++ b/guarddog/analyzer/analyzer.py
@@ -389,6 +389,9 @@ class Analyzer:
             # filtering the full ruleset witht the user's input
             all_rules = self.yara_ruleset & rules
 
+        # Sort for deterministic result/rule ordering across machines (#828)
+        all_rules = sorted(all_rules)
+
         results = {rule: {} for rule in all_rules}  # type: dict
         errors: Dict[str, str] = {}
         issues = 0

--- a/guarddog/analyzer/analyzer.py
+++ b/guarddog/analyzer/analyzer.py
@@ -438,11 +438,14 @@ class Analyzer:
                 hits_found = 0
                 should_stop = False
 
-                for root, _, files in os.walk(path):
+                for root, dirs, files in os.walk(path):
                     if should_stop:
                         break
 
-                    for f in files:
+                    # Sort for deterministic max_hits results across machines (#828)
+                    dirs.sort()
+
+                    for f in sorted(files):
                         if should_stop:
                             break
 


### PR DESCRIPTION
fixes #828