### PR TITLE
feat(npm): add --exclude-dev flag to skip devDependencies in local scans

### DIFF
--- a/guarddog/cli.py
+++ b/guarddog/cli.py
@@ -556,12 +556,18 @@ class CliEcosystem(click.Group):
             )
 
         def _build_verify_command():
-            @click.command("verify", help=f"Verify a given {self.ecosystem.name} package")
+            @click.command(
+                "verify", help=f"Verify a given {self.ecosystem.name} package"
+            )
             @common_options
             @verify_options
             @rule_options
             def verify_ecosystem(
-                target, rules, exclude_rules, output_format, exit_non_zero_on_finding,
+                target,
+                rules,
+                exclude_rules,
+                output_format,
+                exit_non_zero_on_finding,
                 **kwargs,
             ):
                 return _verify(

--- a/guarddog/cli.py
+++ b/guarddog/cli.py
@@ -151,12 +151,19 @@ def _get_rule_param(
 
 
 def _verify(
-    path, rules, exclude_rules, output_format, exit_non_zero_on_finding, ecosystem
+    path,
+    rules,
+    exclude_rules,
+    output_format,
+    exit_non_zero_on_finding,
+    ecosystem,
+    exclude_dev: bool = False,
 ):
     """Verify a requirements.txt file
 
     Args:
         path (str): path to requirements.txt file
+        exclude_dev (bool): skip devDependencies (npm only)
     """
     return_value = None
     rule_param = _get_rule_param(rules, exclude_rules, ecosystem)
@@ -165,7 +172,10 @@ def _verify(
         log.error(f"Command verify is not supported for ecosystem {ecosystem}")
         exit(1)
 
-    dependencies, results = scanner.scan_local(path=path, rules=rule_param)
+    scan_kwargs = {"path": path, "rules": rule_param}
+    if exclude_dev:
+        scan_kwargs["exclude_dev"] = True
+    dependencies, results = scanner.scan_local(**scan_kwargs)
 
     rule_docs = list(rule_param or _get_all_rules(ecosystem=ecosystem))
 
@@ -545,21 +555,43 @@ class CliEcosystem(click.Group):
                 zip_password=zip_password,
             )
 
-        @click.command("verify", help=f"Verify a given {self.ecosystem.name} package")
-        @common_options
-        @verify_options
-        @rule_options
-        def verify_ecosystem(
-            target, rules, exclude_rules, output_format, exit_non_zero_on_finding
-        ):
-            return _verify(
-                target,
-                rules,
-                exclude_rules,
-                output_format,
-                exit_non_zero_on_finding,
-                self.ecosystem,
-            )
+        def _build_verify_command():
+            @click.command("verify", help=f"Verify a given {self.ecosystem.name} package")
+            @common_options
+            @verify_options
+            @rule_options
+            def verify_ecosystem(
+                target, rules, exclude_rules, output_format, exit_non_zero_on_finding,
+                **kwargs,
+            ):
+                return _verify(
+                    target,
+                    rules,
+                    exclude_rules,
+                    output_format,
+                    exit_non_zero_on_finding,
+                    self.ecosystem,
+                    exclude_dev=kwargs.get("exclude_dev", False),
+                )
+
+            # --exclude-dev is npm-specific: devDependencies have no equivalent
+            # in other ecosystems (PyPI, Go modules, RubyGems, Rust crates).
+            if self.ecosystem == ECOSYSTEM.NPM:
+                verify_ecosystem = click.option(
+                    "--exclude-dev",
+                    is_flag=True,
+                    default=False,
+                    help=(
+                        "Exclude devDependencies from the scan. "
+                        "Only production dependencies (under the 'dependencies' key) "
+                        "are scanned. Useful when auditing a package for supply-chain "
+                        "risk in production deployments."
+                    ),
+                )(verify_ecosystem)
+
+            return verify_ecosystem
+
+        verify_ecosystem = _build_verify_command()
 
         @click.command(
             "list-rules", help=f"List available rules for {self.ecosystem.name}"

--- a/guarddog/scanners/npm_project_scanner.py
+++ b/guarddog/scanners/npm_project_scanner.py
@@ -2,10 +2,17 @@ import json
 import logging
 import os
 import re
-from typing import List
+import typing
+from typing import List, Tuple
 
 from guarddog.scanners.npm_package_scanner import NPMPackageScanner
-from guarddog.scanners.scanner import Dependency, DependencyVersion, ProjectScanner
+from guarddog.scanners.scanner import (
+    Dependency,
+    DependencyFile,
+    DependencyVersion,
+    ProjectScanner,
+    noop,
+)
 from guarddog.utils.config import VERIFY_EXHAUSTIVE_DEPENDENCIES
 from guarddog.utils.npm import (
     find_all_versions,
@@ -27,13 +34,18 @@ class NPMRequirementsScanner(ProjectScanner):
     def __init__(self) -> None:
         super().__init__(NPMPackageScanner())
 
-    def parse_requirements(self, raw_requirements: str) -> List[Dependency]:
+    def parse_requirements(
+        self, raw_requirements: str, exclude_dev: bool = False
+    ) -> List[Dependency]:
         """
         Parses requirements.txt specification and finds all valid
         versions of each dependency
 
         Args:
             raw_requirements (str): contents of package file
+            exclude_dev (bool): when True, devDependencies are skipped and
+                only production dependencies are scanned. Defaults to False
+                (scan all dependencies).
 
         Returns:
             dict: mapping of dependencies to valid versions
@@ -48,7 +60,8 @@ class NPMRequirementsScanner(ProjectScanner):
         package = json.loads(raw_requirements)
         dependencies_attr = package["dependencies"] if "dependencies" in package else {}
         dev_dependencies_attr = (
-            package["devDependencies"] if "devDependencies" in package else {}
+            {} if exclude_dev
+            else package.get("devDependencies", {})
         )
         raw_requirement_lines = raw_requirements.splitlines()
 
@@ -116,6 +129,55 @@ class NPMRequirementsScanner(ProjectScanner):
             dep.versions.update(dep_versions)
 
         return dependencies
+
+    def scan_local(
+        self,
+        path: str,
+        rules=None,
+        callback: typing.Callable[[dict], None] = noop,
+        exclude_dev: bool = False,
+    ) -> Tuple[List[DependencyFile], list[dict]]:
+        """
+        Scans a local package.json file or directory, with optional
+        exclusion of devDependencies.
+
+        Args:
+            path (str): path to package.json or directory to search
+            rules: list of rules to apply
+            callback: callback to call for each result
+            exclude_dev (bool): when True, devDependencies are skipped.
+                Only production dependencies under the "dependencies" key
+                are scanned. Defaults to False.
+
+        Returns:
+            Tuple of (dependency files, scan results)
+        """
+        requirement_paths = []
+
+        if os.path.isfile(path):
+            requirement_paths.append(path)
+        elif os.path.isdir(path):
+            requirement_paths.extend(self.find_requirements(path))
+        else:
+            raise ValueError(f"unable to find file or directory {path}")
+
+        dep_files: List[DependencyFile] = []
+
+        for req in requirement_paths:
+            with open(req, "r") as f:
+                dep_files.append(
+                    DependencyFile(
+                        file_path=req,
+                        dependencies=self.parse_requirements(
+                            f.read(), exclude_dev=exclude_dev
+                        ),
+                    )
+                )
+
+        deps_to_scan = [d for d_file in dep_files for d in d_file.dependencies]
+        results = self.scan_dependencies(deps_to_scan, rules, callback)
+
+        return dep_files, results
 
     def find_requirements(self, directory: str) -> list[str]:
         requirement_files = []

--- a/guarddog/scanners/npm_project_scanner.py
+++ b/guarddog/scanners/npm_project_scanner.py
@@ -60,8 +60,7 @@ class NPMRequirementsScanner(ProjectScanner):
         package = json.loads(raw_requirements)
         dependencies_attr = package["dependencies"] if "dependencies" in package else {}
         dev_dependencies_attr = (
-            {} if exclude_dev
-            else package.get("devDependencies", {})
+            {} if exclude_dev else package.get("devDependencies", {})
         )
         raw_requirement_lines = raw_requirements.splitlines()
 

--- a/guarddog/scanners/scanner.py
+++ b/guarddog/scanners/scanner.py
@@ -374,9 +374,11 @@ class ProjectScanner:
         user = os.getenv("GIT_USERNAME")
         personal_access_token = os.getenv("GH_TOKEN")
         if not user or not personal_access_token:
-            log.error("""WARNING: Please set GIT_USERNAME (Github handle) and GH_TOKEN
+            log.error(
+                """WARNING: Please set GIT_USERNAME (Github handle) and GH_TOKEN
                 (generate a personal access token in Github settings > developer)
-                as environment variables before proceeding.""")
+                as environment variables before proceeding."""
+            )
             exit(1)
         return (user, personal_access_token)
 

--- a/tests/core/test_npm_requirements_scanner.py
+++ b/tests/core/test_npm_requirements_scanner.py
@@ -74,6 +74,65 @@ def test_npm_requirements_scanner_alias():
     assert len(lookup.versions) > 0
 
 
+def test_npm_requirements_scanner_exclude_dev_omits_dev_deps():
+    """When exclude_dev=True, devDependencies must not appear in the output."""
+    scanner = NPMRequirementsScanner()
+    result = scanner.parse_requirements(
+        """
+    {
+        "dependencies": {
+            "express": "4.x"
+        },
+        "devDependencies": {
+            "jest": "^29.0.0",
+            "typescript": "^5.0.0"
+        }
+    }
+    """,
+        exclude_dev=True,
+    )
+    names = [d.name for d in result]
+    assert "express" in names, "production dependency must be included"
+    assert "jest" not in names, "jest is a devDependency and must be excluded"
+    assert "typescript" not in names, "typescript is a devDependency and must be excluded"
+
+
+def test_npm_requirements_scanner_include_dev_by_default():
+    """Default behavior (exclude_dev=False) must include devDependencies."""
+    scanner = NPMRequirementsScanner()
+    result = scanner.parse_requirements(
+        """
+    {
+        "dependencies": {
+            "cors": "*"
+        },
+        "devDependencies": {
+            "jest": "^29.0.0"
+        }
+    }
+    """
+    )
+    names = [d.name for d in result]
+    assert "cors" in names
+    assert "jest" in names, "devDependency must be present when exclude_dev is not set"
+
+
+def test_npm_requirements_scanner_exclude_dev_no_prod_deps():
+    """exclude_dev=True with only devDependencies and no dependencies key returns no deps."""
+    scanner = NPMRequirementsScanner()
+    result = scanner.parse_requirements(
+        """
+    {
+        "devDependencies": {
+            "jest": "^29.0.0"
+        }
+    }
+    """,
+        exclude_dev=True,
+    )
+    assert result == [], "no production dependencies → empty list"
+
+
 def test_npm_requirements_scanner_scoped_alias():
     scanner = NPMRequirementsScanner()
     result = scanner.parse_requirements("""


### PR DESCRIPTION
Fixes #528

When auditing a project for supply-chain risk in **production**, `devDependencies` are irrelevant — `npm install --omit=dev` strips them before deployment. Scanning them adds noise and slows CI pipelines.

This PR adds `--exclude-dev` as an npm-only CLI flag for the `verify` subcommand.

## Changes

### `guarddog/scanners/npm_project_scanner.py`
- `parse_requirements()` gains `exclude_dev: bool = False` — when `True`, `devDependencies` is treated as `{}`. Default `False` is fully backward-compatible.
- `scan_local()` overrides the base-class method to thread `exclude_dev` through to `parse_requirements()`.

### `guarddog/cli.py`
- `_verify()` gains `exclude_dev: bool = False`.
- The npm `verify` command is decorated with `--exclude-dev` (is_flag). Other ecosystems do not expose this flag.

## Tests

Three new unit tests in `tests/core/test_npm_requirements_scanner.py`:
- `test_npm_requirements_scanner_exclude_dev_omits_dev_deps` — devDependencies absent, dependencies present when `exclude_dev=True`
- `test_npm_requirements_scanner_include_dev_by_default` — both sections present with default args
- `test_npm_requirements_scanner_exclude_dev_no_prod_deps` — empty result when no `dependencies` key and `exclude_dev=True`

## Usage

```sh
# scan only production dependencies
guarddog npm verify --path ./my-project --exclude-dev

# old behavior unchanged
guarddog npm verify --path ./my-project
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)