### PR TITLE
Fix sandbox blocking dlopen of Homebrew/MacPorts-linked dylibs (macOS)

### DIFF
--- a/guarddog/sandbox.py
+++ b/guarddog/sandbox.py
@@ -137,7 +137,19 @@ def _get_common_read_paths() -> list[str]:
     """Paths that always need READ access for Python + system libs + guarddog rules."""
     paths: set[str] = set()
 
-    candidates = [sys.prefix, sys.base_prefix, "/usr", "/lib"]
+    # /opt/homebrew and /opt/local cover Apple Silicon Homebrew and MacPorts
+    # respectively: pyenv-built interpreters commonly link against libraries
+    # there (OpenSSL, gettext, readline, ...) that live outside sys.prefix,
+    # which the sandbox would otherwise block at dlopen time. Intel Homebrew's
+    # default prefix (/usr/local) is already covered by "/usr" below.
+    candidates = [
+        sys.prefix,
+        sys.base_prefix,
+        "/usr",
+        "/lib",
+        "/opt/homebrew",
+        "/opt/local",
+    ]
 
     # SSL certificate directories: pygit2 initializes OpenSSL at import time and
     # reads the system CA bundle. On Linux (Landlock), only explicitly listed paths

--- a/tests/core/test_sandbox.py
+++ b/tests/core/test_sandbox.py
@@ -63,6 +63,13 @@ class TestApplySandbox:
         paths = _get_common_read_paths()
         assert any(p == os.path.realpath(sys.prefix) for p in paths)
 
+    def test_common_read_paths_includes_macos_package_manager_roots(self):
+        paths = _get_common_read_paths()
+        if os.path.isdir("/opt/homebrew"):
+            assert "/opt/homebrew" in paths
+        if os.path.isdir("/opt/local"):
+            assert "/opt/local" in paths
+
     @patch("guarddog.sandbox.os.getcwd", side_effect=FileNotFoundError)
     def test_common_read_paths_does_not_require_cwd(self, mock_getcwd):
         """Building the common allowlist does not depend on the current directory."""


### PR DESCRIPTION
fix: https://github.com/DataDog/guarddog/issues/852
## Summary
- On Apple Silicon macOS, pyenv-built interpreters commonly link against libraries under `/opt/homebrew` (and MacPorts installs under `/opt/local`), neither of which the sandbox's read allow-list granted, causing `dlopen` failures (e.g. `libssl.3.dylib`, `libintl.8.dylib`) reported as "blocked by sandbox" — both for in-process scans and sandboxed archive extraction.
- Adds `/opt/homebrew` and `/opt/local` to the existing fixed candidate list in `_get_common_read_paths()`, mirroring how `/usr` and `/lib` are already handled (silently dropped via the existing `os.path.isdir()` filter when absent, e.g. on Linux or Intel Macs without Homebrew).

## Test plan
- [x] Added `test_common_read_paths_includes_macos_package_manager_roots` to `tests/core/test_sandbox.py`
- [x] `poetry run make` / `make test` / `make lint` / `make format`
- [x] Verify `guarddog pypi scan requests` succeeds on a real Homebrew/pyenv setup that previously reproduced the bug, both via `poetry run guarddog` and a plain installed binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)