### PR TITLE
Exclude tests from release source tarballs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/tests export-ignore


### PR DESCRIPTION
Closes #776. Adds a `.gitattributes` `export-ignore` so `tests/` stays out of the source tarballs GitHub generates for each release, which is where the sample malicious files sit and where an EDR trips.

Digging in, the PyPI artifacts already leave tests out. The 3.2.0 sdist and wheel (and the older releases I spot-checked back to 2.0.0) have nothing under `tests/`, and building locally with the pinned `poetry==2.3.4` from `.github/workflows/requirements.txt` gives the same result. The one release tarball still carrying the test files is the source archive attached to each GitHub release, i.e. the `git archive` output, so that's what this targets.

`export-ignore` only affects `git archive`, so CI, `poetry build`, and local `uv run pytest` are all untouched. The tests still live in the repo and run normally.

Verified against current `v3` HEAD:

```
# before (parent commit)
$ git archive HEAD~1 | tar t | grep -c '^tests/'
142

# after
$ git archive HEAD | tar t | grep -c '^tests/'
0

# guarddog package and its .yar rules still in the archive
$ git archive HEAD | tar t | grep -c '^guarddog/'
149
```
