### PR TITLE
fix(analyzer): prevent triple quote false negatives

### DIFF
--- a/guarddog/analyzer/analyzer.py
+++ b/guarddog/analyzer/analyzer.py
@@ -139,13 +139,34 @@ class Analyzer:
                 if last_open > last_close:
                     return True
 
-            elif language == LANGUAGE.PYTHON:
-                # For Python, check if we're inside """ or '''
-                for quote in ['"""', "'''"]:
-                    # Count occurrences - if odd, we're inside a docstring
-                    count = window.count(quote)
-                    if count % 2 == 1:
-                        return True
+                elif language == LANGUAGE.PYTHON:
+                    quote = None
+                    i = 0
+
+                while i < len(window):
+                    if window[i] == "\\":
+                        i += 2
+                        continue
+
+                    if quote:
+                        if window.startswith(quote, i):
+                            quote = None
+                            i += 3
+                            continue
+                    else:
+                        if window.startswith('"""', i):
+                            quote = '"""'
+                            i += 3
+                            continue
+                        if window.startswith("'''", i):
+                            quote = "'''"
+                            i += 3
+                            continue
+
+                    i += 1
+
+                if quote:
+                    return True
 
         except Exception:
             pass

--- a/tests/core/test_sourcecode_analyzer.py
+++ b/tests/core/test_sourcecode_analyzer.py
@@ -414,3 +414,38 @@ def test_is_match_in_comment_with_byte_offset():
             assert Analyzer.is_match_in_comment(f.name, line_number=3, byte_offset=byte_offset) is True
         finally:
             os.unlink(f.name)
+
+def test_is_in_multiline_comment_python_triple_quotes_in_string():
+    """Test that triple quotes inside a string are not treated as a docstring."""
+    f = tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False)
+    try:
+        f.write("banner = '\"\"\"'\n")
+        f.write("result = os.homedir()\n")
+        f.close()
+
+        byte_offset = len("banner = '\"\"\"'\nresult = ".encode())
+
+        assert Analyzer._is_in_multiline_comment(
+            f.name,
+            LANGUAGE.PYTHON,
+            byte_offset=byte_offset,
+        ) is False
+    finally:
+        os.unlink(f.name)
+def test_is_in_multiline_comment_python_triple_quotes_in_comment():
+    """Test that triple quotes inside a comment are not treated as a docstring."""
+    f = tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False)
+    try:
+        f.write("# \"\"\"\n")
+        f.write("result = os.homedir()\n")
+        f.close()
+
+        byte_offset = len("# \"\"\"\nresult = ".encode())
+
+        assert Analyzer._is_in_multiline_comment(
+            f.name,
+            LANGUAGE.PYTHON,
+            byte_offset=byte_offset,
+        ) is False
+    finally:
+        os.unlink(f.name)


### PR DESCRIPTION
Closes #831

The previous Python triple-quote parity check could treat triple quotes
inside string values or comments as an open docstring and suppress
YARA matches.

This replaces the parity check with quote-state tracking and adds
regression tests for triple quotes inside strings and comments.