### PR TITLE
fix(npm): reject package-lock.json in npm verify with a clear error

### DIFF
--- a/guarddog/scanners/npm_project_scanner.py
+++ b/guarddog/scanners/npm_project_scanner.py
@@ -49,6 +49,12 @@ class NPMRequirementsScanner(ProjectScanner):
             }
         """
         package = json.loads(raw_requirements)
+        if "lockfileVersion" in package:
+            raise ValueError(
+                "Unsupported file format: this looks like a package-lock.json. "
+                "GuardDog's npm verify expects a package.json manifest; point the "
+                "command at your package.json instead."
+            )
         dependencies_attr = package["dependencies"] if "dependencies" in package else {}
         dev_dependencies_attr = (
             package["devDependencies"] if "devDependencies" in package else {}

--- a/tests/core/test_npm_requirements_scanner.py
+++ b/tests/core/test_npm_requirements_scanner.py
@@ -1,6 +1,8 @@
 import os
 import pathlib
 
+import pytest
+
 import guarddog.scanners.npm_project_scanner as npm_project_scanner
 from guarddog.scanners.npm_project_scanner import NPMRequirementsScanner
 
@@ -131,3 +133,36 @@ def test_npm_requirements_scanner_includes_dev_dependencies_when_enabled(monkeyp
     dependency_names = {dependency.name for dependency in result}
     assert "express" in dependency_names
     assert "joi" in dependency_names
+
+
+def test_npm_requirements_scanner_rejects_lockfile():
+    """Passing a package-lock.json must fail with a clear error instead of
+    silently returning no dependencies (v3) or crashing on dict selectors (v2).
+    """
+    scanner = NPMRequirementsScanner()
+
+    # lockfile v3 has only a top-level "packages" map, no "dependencies".
+    with pytest.raises(ValueError, match="package-lock"):
+        scanner.parse_requirements("""
+        {
+            "name": "proj",
+            "lockfileVersion": 3,
+            "requires": true,
+            "packages": {
+                "": {"name": "proj", "dependencies": {"express": "4.19.2"}},
+                "node_modules/express": {"version": "4.19.2"}
+            }
+        }
+        """)
+
+    # lockfile v2 has a top-level "dependencies" map whose values are objects.
+    with pytest.raises(ValueError, match="package-lock"):
+        scanner.parse_requirements("""
+        {
+            "name": "proj",
+            "lockfileVersion": 2,
+            "dependencies": {
+                "express": {"version": "4.19.2"}
+            }
+        }
+        """)


### PR DESCRIPTION
## Summary
`guarddog npm verify <path>` silently returned **no dependencies** when pointed at a `package-lock.json`:
- **lockfile v3**: no top-level `dependencies` key → `parse_requirements` returns `[]` with no message (exact behavior reported in #863).
- **lockfile v2**: top-level `dependencies` values are dicts → crash in `resolve_npm_alias` with `TypeError: expected string or bytes-like object, got 'dict'`.

The `lockfileVersion` key is a reliable package-lock.json marker (it never appears in a package.json manifest). This PR detects it in `NPMRequirementsScanner.parse_requirements` and raises a `ValueError` with an actionable message pointing the user at their `package.json` instead.

## Changes
- `guarddog/scanners/npm_project_scanner.py`: raise `ValueError` when `lockfileVersion` is present.
- `tests/core/test_npm_requirements_scanner.py`: regression test covering both lockfile v3 and v2 shapes.

## Scope note
This is an *error-scope* fix (fail cleanly with a clear message), not full lockfile parsing support. It mirrors the pypi `verify` behavior of rejecting wrong file formats. Full lockfile support would be a larger feature.

## Test plan
- `pytest tests/core/test_npm_requirements_scanner.py` → 8/8 pass (7 pre-existing + 1 new).
- `black --check guarddog/scanners/npm_project_scanner.py` → clean.
- `flake8 guarddog` (both Makefile lint targets) → 0 errors.
- Manual: `guarddog npm verify package-lock.json` now prints a clear error and exits non-zero instead of silently returning no findings.

## Disclosure
This PR was developed with assistance from an AI coding assistant (Claude). The approach, code, and tests were reviewed by a human contributor.

Closes #863