### PR TITLE
fix(rules): require whitespace/paren boundary for JS eval in obfuscation rules

### DIFF
--- a/guarddog/analyzer/sourcecode/threat-runtime-obfuscation-base64exec.yar
+++ b/guarddog/analyzer/sourcecode/threat-runtime-obfuscation-base64exec.yar
@@ -25,7 +25,8 @@ rule threat_runtime_obfuscation_base64exec
         $js_atob = /\batob\s*\(/ nocase
         // Buffer.from with explicit base64 encoding (not just any Buffer.from)
         $js_buffer_b64 = /Buffer\s*\.\s*from\s*\([^)]*['"]base64['"]/ nocase
-        $js_eval = /\beval\s*\(/ nocase
+        // bare eval(, not method calls like page.$eval() or obj.eval()
+        $js_eval = /(^|\s|\()eval\s*\(/ nocase
         $js_function = /\bnew\s+Function\s*\(/ nocase
 
         // Go - base64 decode + exec

--- a/guarddog/analyzer/sourcecode/threat-runtime-obfuscation-steganography.yar
+++ b/guarddog/analyzer/sourcecode/threat-runtime-obfuscation-steganography.yar
@@ -26,7 +26,8 @@ rule threat_runtime_obfuscation_steganography
         $js_jimp = "Jimp.read(" nocase
         $js_getpixel = "getPixelColor(" nocase
         $js_buffer_concat = "Buffer.concat(" nocase
-        $js_eval = "eval(" nocase
+        // bare eval(, not method calls like page.$eval() or obj.eval()
+        $js_eval = /(^|\s|\()eval\s*\(/ nocase
 
         // Image file references in code
         $img_png = /\.(png|jpg|jpeg|gif|bmp)['"]/ nocase

--- a/tests/analyzer/sourcecode/benign/threat-runtime-obfuscation-base64exec.js
+++ b/tests/analyzer/sourcecode/benign/threat-runtime-obfuscation-base64exec.js
@@ -1,0 +1,9 @@
+// Benign regression test for threat-runtime-obfuscation-base64exec.
+// A base64-encoded fixture blob sits in the same file as Playwright's
+// page.$eval selector method, which is not the bare execution builtin.
+// This must not trigger.
+const fixture = Buffer.from(rawFixture, 'base64');
+
+async function readCount(page) {
+  return page.$eval('#count', (el) => el.textContent);
+}

--- a/tests/analyzer/sourcecode/benign/threat-runtime-obfuscation-steganography.js
+++ b/tests/analyzer/sourcecode/benign/threat-runtime-obfuscation-steganography.js
@@ -1,0 +1,10 @@
+// Benign regression test for the image-obfuscation runtime detection rule.
+// Buffer.concat() and a PNG asset path sit near Playwright's page.$eval
+// selector method, which is not the bare execution builtin, so this must
+// not trigger.
+const icon = './assets/logo.png';
+const combined = Buffer.concat([a, b]);
+
+async function readCount(page) {
+  return page.$eval('#count', (el) => el.textContent);
+}

--- a/tests/analyzer/sourcecode/threat-runtime-obfuscation-base64exec.js
+++ b/tests/analyzer/sourcecode/threat-runtime-obfuscation-base64exec.js
@@ -1,0 +1,4 @@
+// Positive test for threat-runtime-obfuscation-base64exec.
+// Base64-decoded payload run through the bare eval() builtin.
+const payload = atob(encoded);
+eval(payload);

--- a/tests/analyzer/sourcecode/threat-runtime-obfuscation-steganography.js
+++ b/tests/analyzer/sourcecode/threat-runtime-obfuscation-steganography.js
@@ -1,0 +1,4 @@
+// Positive test for threat-runtime-obfuscation-steganography.
+// Hidden payload recovered from a PNG then run through the bare eval() builtin.
+const hidden = stego.decode('cover.png');
+eval(hidden);


### PR DESCRIPTION
Fixes #868

## Root cause

`threat-runtime-obfuscation-base64exec` and `threat-runtime-obfuscation-steganography` both matched bare `eval(` in JS with a pattern whose left-hand boundary wasn't strict enough to exclude method calls like Playwright/Puppeteer's `page.$eval(...)`:

- `base64exec`'s `$js_eval = /\beval\s*\(/` still matches right before "eval" in `$eval(`, since `$` is a non-word character and `\b` only requires a word/non-word transition, not whitespace.
- `steganography`'s `$js_eval = "eval(" nocase` was a bare substring with no boundary check at all.

Reproduced directly against the real package from the report: `pi-markdown-preview@0.14.1`'s `test/regressions.mjs` contains `page.$eval(...)` calls alongside a genuine `Buffer.from(..., 'base64')` fixture and 19 PNG asset references in quotes — tripping both rules purely on the `$eval` false match, independent of any real obfuscation.

## Fix

Reuse the eval-boundary pattern already established in `capability-process-spawn.yar`:

```
$js_eval = /(^|\s|\()eval\s*\(/ nocase
```

This requires `eval` to be preceded by start-of-file, whitespace, or an open paren, excluding `$eval`/`.eval`-style method calls while still matching bare `eval(...)` invocations, including `eval (payload)` with a space before the parenthesis.

## Verification

- Downloaded the real `pi-markdown-preview@0.14.1` npm package and confirmed via direct `yara-python` compile+match that both rules fire on the unmodified rule set (red) and neither fires after the fix (green).
- Added `tests/analyzer/sourcecode/threat-runtime-obfuscation-{base64exec,steganography}.js` positive tests locking in that a real `atob(...)`/`stego.decode(...)` payload run through bare `eval(...)` is still detected.
- Added `tests/analyzer/sourcecode/benign/threat-runtime-obfuscation-{base64exec,steganography}.js` benign tests locking in the exact `page.$eval(...)` false-positive shape.
- Full sourcecode YARA suite passes: 132/132 relevant tests (`uv run pytest tests/analyzer/sourcecode`). Two unrelated pre-existing fixtures for a different rule (`threat-runtime-obfuscation-dynamic-eval`, `npm-exfiltrate-sensitive-data`) get quarantined by Windows Defender on this dev machine since they intentionally mimic malicious code for other rules' tests — confirmed via `Get-MpThreatDetection`, unrelated to this change and not part of this diff.